### PR TITLE
Profile Template

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import Breadcrumb from './components/ui/molecule/breadcrumb';
 
-const longPages = [
-  { name: 'HEFTI Homepage', href: '#', current: false },
-  { name: 'All Nursing Homes', href: '#', current: false },
-  { name: 'Aspen Point Health and Rehabilitation', href: '#', current: false },
-  { name: 'Report Builder', href: '#', current: true },
-];
+import ProfileTemplate from './components/ui/template/profileTemplate';
 
 function App() {
   return (
     <div className="">
-      <Breadcrumb pages={longPages} />
+      <ProfileTemplate />
     </div>
   );
 }

--- a/src/components/ui/molecule/breadcrumb.jsx
+++ b/src/components/ui/molecule/breadcrumb.jsx
@@ -18,6 +18,7 @@ const defaultPages = [
   { name: 'Current Page', href: '#', current: true },
 ];
 //Ask Nick about hover color, leaving stock for now
+//Note: defaultPages is for Storybook
 export default function Breadcrumb({ pages = defaultPages }) {
   return (
     <BreadcrumbLayoutCard className="bg-zinc-200">

--- a/src/components/ui/molecule/tabs.jsx
+++ b/src/components/ui/molecule/tabs.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import { ChevronDownIcon } from '@heroicons/react/16/solid';
 import { useState } from 'react';
 
@@ -5,44 +7,54 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
 
+Tabs.propTypes = {
+  tabsData: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      href: PropTypes.string,
+      current: PropTypes.bool,
+      displayTitle: PropTypes.string,
+    }),
+  ),
+  onTabChange: PropTypes.func,
+  activeTab: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    href: PropTypes.string,
+    current: PropTypes.bool,
+    displayTitle: PropTypes.string,
+  }),
+};
+
 /**
  *
  * This component is based on UI/Application Tabs/Tabs with underline
- * It takes a tabsData Prop which represents the static values for the tab title
- * When used with tabsWithHeader it needs the onTabChange prop to track the active tab
+ * Props:
+ * - tabsData: array of tabs
+ * - activeTab: the currently active tab
+ * - onTabChange: callback when a tab is clicked
  * example:  <Tabs tabsData={tabsData} onTabChange={setActiveTab}/>
  */
 
-export default function Tabs({ tabsData = [], onTabChange }) {
-  const [tabs, setTabs] = useState(
-    tabsData.map((tab, i) => ({ ...tab, current: i === 0 })),
-  );
-
-  //Updates the tabs state with the new current tab. Updates onTabChange with new current and shares that with parent component.
+export default function Tabs({ tabsData = [], onTabChange, activeTab }) {
   const handleClick = (tabName) => {
-    setTabs((prevTabs) => {
-      const updated = prevTabs.map((tab) => ({
-        ...tab,
-        current: tab.name === tabName,
-      }));
-
-      const newActive = updated.find((tab) => tab.current);
+    const newActive = tabsData.find((tab) => tab.name === tabName);
+    if (newActive) {
       onTabChange?.(newActive);
-      return updated;
-    });
+    }
   };
 
+  console.log(activeTab.name);
   return (
     <div className="bg-background-secondary">
       <div className="grid grid-cols-1 sm:hidden">
         {/* Use an "onChange" listener to redirect the user to the selected tab URL. */}
         <select
           onChange={(e) => handleClick(e.target.value)}
-          defaultValue={tabs.find((tab) => tab.current).name}
+          value={activeTab?.name}
           aria-label="Select a tab"
           className="text-paragraph-sm col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pr-8 pl-3 text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-blue-700"
         >
-          {tabs.map((tab) => (
+          {tabsData.map((tab) => (
             <option key={tab.name}>{tab.name}</option>
           ))}
         </select>
@@ -54,7 +66,7 @@ export default function Tabs({ tabsData = [], onTabChange }) {
       <div className="hidden sm:block">
         <div className="border-b border-gray-200">
           <nav aria-label="Tabs" className="-mb-px flex space-x-8">
-            {tabs.map((tab) => (
+            {tabsData.map((tab) => (
               <a
                 key={tab.name}
                 href={tab.href}
@@ -62,9 +74,9 @@ export default function Tabs({ tabsData = [], onTabChange }) {
                   e.preventDefault();
                   handleClick(tab.name);
                 }}
-                aria-current={tab.current ? 'page' : undefined}
+                aria-current={activeTab.name === tab.name ? 'page' : undefined}
                 className={classNames(
-                  tab.current
+                  activeTab?.name === tab.name
                     ? 'border-blue-700 font-bold text-blue-700'
                     : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
                   'text-paragraph-sm border-b-2 px-1 py-4 whitespace-nowrap',

--- a/src/components/ui/molecule/tabs.jsx
+++ b/src/components/ui/molecule/tabs.jsx
@@ -32,7 +32,7 @@ Tabs.propTypes = {
  * - tabsData: array of tabs
  * - activeTab: the currently active tab
  * - onTabChange: callback when a tab is clicked
- * example:  <Tabs tabsData={tabsData} onTabChange={setActiveTab}/>
+ * example:  <Tabs tabsData={tabsData} onTabChange={setActiveTab} activeTab={activeTab}/>
  */
 
 export default function Tabs({ tabsData = [], onTabChange, activeTab }) {

--- a/src/components/ui/molecule/tabsWithHeader.jsx
+++ b/src/components/ui/molecule/tabsWithHeader.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import SectionHeader from '../molecule/sectionHeader';
 import Tabs from './Tabs';
 
@@ -34,12 +35,16 @@ const TABS = [
  *We manage the activeTab state here witch sets the default to the first tab.  This is passed down to the Tabs component.
  */
 
-export default function TabsWithHeader() {
-  const [activeTab, setActiveTab] = useState(TABS[0]);
+export default function TabsWithHeader({ tabsData = TABS }) {
+  const [activeTab, setActiveTab] = useState(tabsData[0]);
   return (
     <div className="bg-background-secondary">
       <div className="pb-3">
-        <Tabs tabsData={TABS} onTabChange={setActiveTab} />
+        <Tabs
+          tabsData={tabsData}
+          onTabChange={setActiveTab}
+          activeTab={activeTab}
+        />
       </div>
       <div className="py-6">
         <SectionHeader title={activeTab.displayTitle} variant="primary" />
@@ -47,3 +52,13 @@ export default function TabsWithHeader() {
     </div>
   );
 }
+
+TabsWithHeader.propTypes = {
+  tabsData: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      displayTitle: PropTypes.string.isRequired,
+      href: PropTypes.string,
+    }),
+  ),
+};

--- a/src/components/ui/template/profileTemplate.jsx
+++ b/src/components/ui/template/profileTemplate.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import LayoutPage from '../atom/layout-page';
+import HeftiNavbar from '../molecule/heftiNavbar';
+import ProfileHeader from '../molecule/profileHeader';
+import TabsWithHeader from '../molecule/tabsWithHeader';
+import Footer from '../molecule/footer';
+import Breadcrumb from '../molecule/breadcrumb';
+import LayoutCard from '../atom/layout-card';
+
+const tabsData = [
+  {
+    name: '[selected tab]',
+    displayTitle: '[selected tab]',
+    href: '#',
+  },
+  {
+    name: '[additional tab 1]',
+    displayTitle: '[selected tab]',
+    href: '#',
+  },
+  {
+    name: '[additional tab 2]',
+    displayTitle: '[selected tab]',
+    href: '#',
+  },
+  {
+    name: '[additional tab 3]',
+    displayTitle: '[selected tab]',
+    href: '#',
+  },
+  {
+    name: '[additional tab 4]',
+    displayTitle: '[selected tab]',
+    href: '#',
+  },
+];
+
+//This component is for storybook display only
+//Not sure at this time if I need to make a reusable component out of the placeholder content below or a one time use?
+
+export default function ProfileTemplate() {
+  return (
+    <div className="bg-background-secondary">
+      <HeftiNavbar />
+      <Breadcrumb />
+      <LayoutPage>
+        <ProfileHeader
+          title={'[variable=Name]'}
+          badges={[
+            { title: '[variable=Ownership_Type]', color: 'zinc' },
+            { title: '[BADGE TITLE]', color: 'zinc' },
+            { title: '[BADGE TITLE]', color: 'zinc' },
+          ]}
+        />
+        <TabsWithHeader tabsData={tabsData} />
+
+        {/* Placeholder for Content */}
+        <div className="mb-8">
+          <LayoutCard>
+            <div className="flex h-[620px] items-center justify-center bg-gray-100">
+              <h1 className="text-display-sm text-content-tertiary">
+                CORE CONTENT
+              </h1>
+            </div>
+          </LayoutCard>
+        </div>
+      </LayoutPage>
+      <Footer />
+    </div>
+  );
+}

--- a/src/stories/template/ProfileTemplate.stories.jsx
+++ b/src/stories/template/ProfileTemplate.stories.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ProfileTemplate from '../../components/ui/template/profileTemplate';
+import { MemoryRouter } from 'react-router-dom';
+
+export default {
+  title: 'COMPONENTS/Template/ProfileTemplate',
+  component: ProfileTemplate,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+const Template = (args) => <ProfileTemplate {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};


### PR DESCRIPTION
The main component is ProfileTemplate which is a storybook layout owner or facility profiles with a placeholder for content.

Doing this required me to allow tabsData to be a prop that can be passed in to set the titles on each tab for specific use cases, instead of hardcoded for one use case. Upon doing that I discovered a little bug in my previous setup that required changes in tabs.tsx and its parent component tabsWithHeader.jsx.

To address this, I removed state from tabs.jsx and lifted it to its parent tabsWithHeader.jsx to manage and which passing it down to tabs.jsx.  Implemented a much simpler handClick function that sets the new ActiveTab back in the parent component with the OnTabChange callback.  This setup is working in both the profileTemplate and current FacilityProfile.  Will be easy to adopt to any future use cases calling for this tabs layout.