### PR TITLE
fix: relplacing data variables with new ones

### DIFF
--- a/src/components/ui/molecule/ownerProfileDescription.jsx
+++ b/src/components/ui/molecule/ownerProfileDescription.jsx
@@ -32,7 +32,7 @@ export default function OwnerProfileDescription({ items }) {
               TOTAL DEFICIENCIES
             </p>
             <p className="">
-              {items.cms_owner_n_deficiencies?.toLocaleString() || '—'}
+              {items.cms_owner_total_deficiencies?.toLocaleString() || '—'}
             </p>
           </div>
 
@@ -125,7 +125,7 @@ OwnerProfileDescription.propTypes = {
     cms_owner_total_facilities: PropTypes.number,
     cms_ownership_type: PropTypes.string,
     cms_owner_states: PropTypes.string,
-    cms_owner_n_deficiencies: PropTypes.number,
+    cms_owner_total_deficiencies: PropTypes.number,
     cms_owner_total_penalties: PropTypes.number,
     cms_owner_total_fines: PropTypes.number,
 

--- a/src/components/ui/organism/facilityProviderHighlights.jsx
+++ b/src/components/ui/organism/facilityProviderHighlights.jsx
@@ -20,7 +20,7 @@ export default function FacilityProviderHighlights({ items }) {
     {
       key: 'Total Deficiencies',
       stat: items.health_deficiencies ?? 'N/A',
-      rating: items.national_comparison_deficiencies ?? 'N/A',
+      rating: items.cmpr_health_deficiencies ?? 'N/A',
       description:
         'Average numbor of serious deficiencies found in affiliated homes in the last three years',
       isCurrency: false,
@@ -28,7 +28,7 @@ export default function FacilityProviderHighlights({ items }) {
     {
       key: 'Number of Fines',
       stat: items.number_of_fines ?? 'N/A',
-      rating: items.national_comparison_fines ?? 'N/A',
+      rating: items.cmpr_number_of_fines ?? 'N/A',
       description:
         'Average percentage of nursing staff who stopped working at affiliated homes over a 12-month period',
       isCurrency: false,
@@ -36,7 +36,7 @@ export default function FacilityProviderHighlights({ items }) {
     {
       key: 'Fines Total',
       stat: items.total_amount_of_fines_in_usd ?? 'N/A',
-      rating: items.national_comparison_fines ?? 'N/A',
+      rating: items.cmpr_total_amount_of_fines_in_usd ?? 'N/A',
       description: 'Average total fines against affiliated homes.',
       isCurrency: true,
     },
@@ -106,11 +106,15 @@ FacilityProviderHighlights.propTypes = {
       PropTypes.string,
       PropTypes.number,
     ]),
-    national_comparison_fines: PropTypes.oneOfType([
+    cmpr_number_of_fines: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
     ]),
-    national_comparison_deficiencies: PropTypes.oneOfType([
+    cmpr_health_deficiencies: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    cmpr_total_amount_of_fines_in_usd: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
     ]),

--- a/src/components/ui/organism/ownerProviderHighlights.jsx
+++ b/src/components/ui/organism/ownerProviderHighlights.jsx
@@ -34,24 +34,24 @@ export default function OwenerProviderHighlights({ items, relatedFacilities }) {
   const ownerCardStats = [
     {
       key: 'Average Total Deficiencies',
-      stat: items.cms_owner_average_deficiencies.toFixed(1),
-      rating: items.national_comparison_deficiencies,
+      stat: items.cms_owner_average_deficiencies?.toFixed(1) ?? 'N/A',
+      // rating: items.national_comparison_deficiencies ?? 'N/A',
       description:
         'Average number of serious deficiencies found in affiliated homes in the last three years',
       isCurrency: false,
     },
     {
       key: 'Average Number of Penalties',
-      stat: items.cms_owner_average_penalties,
-      rating: items.national_comparison_penalties,
+      stat: items.cms_owner_average_penalties ?? 'N/A',
+      // rating: items.national_comparison_penalties ?? 'N/A',
       description:
         'Average percentage of nursing staff who stopped working at affiliated homes over a 12-month period',
       isCurrency: false,
     },
     {
       key: 'Average Fine',
-      stat: items.cms_owner_average_fines,
-      rating: items.national_comparison_fines,
+      stat: items.cms_owner_average_fines ?? 'N/A',
+      // rating: items.national_comparison_fines ?? 'N/A',
       description: 'Average total fines against affiliated homes.',
       isCurrency: true,
     },

--- a/src/lib/getBadgeColor.js
+++ b/src/lib/getBadgeColor.js
@@ -1,11 +1,12 @@
 //Helper function to choose badge color/will need to be modified to relect cases where below average is bad or good
 const getBadgeColorAboveBelow = (rating) => {
+  if (!rating) return 'gray';
   switch (rating.toLowerCase()) {
-    case 'above national average':
+    case 'above state average':
       return 'red';
     case 'average':
       return 'yellow';
-    case 'below national average':
+    case 'below state average':
       return 'green';
     default:
       return 'gray';


### PR DESCRIPTION
The variables used by the badges was altered by the new data.

Provided new variable names to badges.

For Owner Profile these card badges no longer have variables fields at all.   For now I just commented it out and no badges are being generated.