### PR TITLE
fix: remove dark mode

### DIFF
--- a/src/components/ui/atom/heading.jsx
+++ b/src/components/ui/atom/heading.jsx
@@ -25,7 +25,7 @@ export function Heading({ className, level = 1, ...props }) {
       className={clsx(
         sizeMap[level],
         className,
-        'text-core-black dark:text-core-white',
+        'text-core-black',
       )}
     />
   );
@@ -39,7 +39,7 @@ export function Subheading({ className, level = 2, ...props }) {
       {...props}
       className={clsx(
         className,
-        'text-base/7 font-semibold text-zinc-950 sm:text-sm/6 dark:text-white',
+        'text-base/7 font-semibold text-zinc-950 sm:text-sm/6',
       )}
     />
   );


### PR DESCRIPTION
Tyler has dark mode enabled.  Dark mode tailwind was inherent on the tailwind catalyst ui kit.  We don't have a dark mode theme, so that is why sometimes it would look fine on default light mode safari but not on Tyler's.  I set my chrome to dark mode by default and had the same issue

<img width="1527" height="803" alt="image" src="https://github.com/user-attachments/assets/0464f876-266f-45a2-9b9b-0dd05fa9d370" />
