### PR TITLE
Network Graph Side Panel

### DIFF
--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -513,13 +513,28 @@ MetricCardLong.propTypes = {
   item: PropTypes.object.isRequired,
 };
 
+/**
+ * Compact metric row for the network graph side panel.
+ *
+ * Responsibilities:
+ * - Renders a single clinical quality or financial metric in a 3-column grid
+ * - Title spans 2 columns; value + detail stats are right-aligned in the third
+ * - Adapts colors between desktop (light) and mobile (dark sheet) via `variant`
+ *
+ * Notes:
+ * - Prefers `displayValue` over `value` — builders attach the formatted suffix there.
+ * - Detail labels abbreviate "Median:" → "Med" and "Std Dev:" → "SD" to fit the
+ *   narrow column; the full strings are preserved in the aria-label for screen readers.
+ */
 export function MetricCardShort({ item, variant }) {
   const isMobile = variant === 'mobile';
   return (
     <div
       className={clsx(
         'grid grid-cols-3 px-4 py-2',
-        isMobile ? 'bg-zinc-900 hover:bg-zinc-800' : 'bg-white hover:bg-gray-50',
+        isMobile
+          ? 'bg-zinc-900 hover:bg-zinc-800'
+          : 'bg-core-white hover:bg-gray-50',
       )}
     >
       {/** Title */}
@@ -558,13 +573,39 @@ export function MetricCardShort({ item, variant }) {
   );
 }
 
+MetricCardShort.propTypes = {
+  item: PropTypes.shape({
+    title: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    detail1: PropTypes.string,
+    detail2: PropTypes.string,
+  }).isRequired,
+  variant: PropTypes.oneOf(['desktop', 'mobile']),
+};
+
+/**
+ * Compact staffing row for the network graph side panel.
+ *
+ * Responsibilities:
+ * - Renders a single staffing metric (levels or turnover) in a 3-column grid
+ * - Title spans 2 columns; stat + median detail are right-aligned in the third
+ * - Adapts colors between desktop (light) and mobile (dark sheet) via `variant`
+ *
+ * Notes:
+ * - Prefers `displayStat` over `stat` — builders attach the formatted suffix there.
+ * - "Median:" is abbreviated to "Med" at render time; the full string is kept in
+ *   aria-label so screen readers get the unabbreviated label.
+ */
 export function StaffingCardShort({ item, variant }) {
   const isMobile = variant === 'mobile';
   return (
     <div
       className={clsx(
         'grid grid-cols-3 px-4 py-2',
-        isMobile ? 'bg-zinc-900 hover:bg-zinc-800' : 'bg-white hover:bg-gray-50',
+        isMobile
+          ? 'bg-zinc-900 hover:bg-zinc-800'
+          : 'bg-core-white hover:bg-gray-50',
       )}
     >
       <div className="col-span-2 self-center">
@@ -599,17 +640,6 @@ export function StaffingCardShort({ item, variant }) {
     </div>
   );
 }
-
-MetricCardShort.propTypes = {
-  item: PropTypes.shape({
-    title: PropTypes.string,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    detail1: PropTypes.string,
-    detail2: PropTypes.string,
-  }).isRequired,
-  variant: PropTypes.oneOf(['desktop', 'mobile']),
-};
 
 StaffingCardShort.propTypes = {
   item: PropTypes.shape({

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -539,6 +539,7 @@ export function MetricCardShort({ item, variant }) {
           {item.value} %
         </p>
         <p
+          aria-label={`${item.detail1}, ${item.detail2}`}
           className={clsx(
             'text-label-xs',
             isMobile ? 'text-content-tertiary' : 'text-content-secondary',
@@ -576,6 +577,7 @@ export function StaffingCardShort({ item, variant }) {
           {item.stat}
         </p>
         <p
+          aria-label={item.detail}
           className={clsx(
             'text-label-xs',
             isMobile ? 'text-content-tertiary' : 'text-content-secondary',

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -516,7 +516,12 @@ MetricCardLong.propTypes = {
 export function MetricCardShort({ item, variant }) {
   const isMobile = variant === 'mobile';
   return (
-    <div className="grid grid-cols-3 bg-white px-4 py-2 hover:bg-gray-50">
+    <div
+      className={clsx(
+        'grid grid-cols-3 px-4 py-2',
+        isMobile ? 'bg-zinc-900 hover:bg-zinc-800' : 'bg-white hover:bg-gray-50',
+      )}
+    >
       {/** Title */}
       <div className="col-span-2 self-center">
         <p
@@ -556,7 +561,12 @@ export function MetricCardShort({ item, variant }) {
 export function StaffingCardShort({ item, variant }) {
   const isMobile = variant === 'mobile';
   return (
-    <div className="grid grid-cols-3 bg-white px-4 py-2 hover:bg-gray-50">
+    <div
+      className={clsx(
+        'grid grid-cols-3 px-4 py-2',
+        isMobile ? 'bg-zinc-900 hover:bg-zinc-800' : 'bg-white hover:bg-gray-50',
+      )}
+    >
       <div className="col-span-2 self-center">
         <p
           className={clsx(

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -536,7 +536,7 @@ export function MetricCardShort({ item, variant }) {
             isMobile ? 'text-core-white' : 'text-core-black',
           )}
         >
-          {item.value} %
+          {item.displayValue ?? item.value}
         </p>
         <p
           aria-label={`${item.detail1}, ${item.detail2}`}
@@ -574,7 +574,7 @@ export function StaffingCardShort({ item, variant }) {
             isMobile ? 'text-core-white' : 'text-core-black',
           )}
         >
-          {item.stat}
+          {item.displayStat ?? item.stat}
         </p>
         <p
           aria-label={item.detail}
@@ -589,6 +589,27 @@ export function StaffingCardShort({ item, variant }) {
     </div>
   );
 }
+
+MetricCardShort.propTypes = {
+  item: PropTypes.shape({
+    title: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    detail1: PropTypes.string,
+    detail2: PropTypes.string,
+  }).isRequired,
+  variant: PropTypes.oneOf(['desktop', 'mobile']),
+};
+
+StaffingCardShort.propTypes = {
+  item: PropTypes.shape({
+    title: PropTypes.string,
+    stat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    displayStat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    detail: PropTypes.string,
+  }).isRequired,
+  variant: PropTypes.oneOf(['desktop', 'mobile']),
+};
 
 /**
  * Compact staffing metric card used in the Staffing tab grid.

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -513,6 +513,81 @@ MetricCardLong.propTypes = {
   item: PropTypes.object.isRequired,
 };
 
+export function MetricCardShort({ item, variant }) {
+  const isMobile = variant === 'mobile';
+  return (
+    <div className="grid grid-cols-3 bg-white px-4 py-2 hover:bg-gray-50">
+      {/** Title */}
+      <div className="col-span-2 self-center">
+        <p
+          className={clsx(
+            'text-label-sm font-medium',
+            isMobile ? 'text-core-white' : 'text-core-black',
+          )}
+        >
+          {item.title}
+        </p>
+      </div>
+      {/** Value + details stacked right */}
+      <div className="flex flex-col items-end">
+        <p
+          className={clsx(
+            'text-label-lg font-medium',
+            isMobile ? 'text-core-white' : 'text-core-black',
+          )}
+        >
+          {item.value} %
+        </p>
+        <p
+          className={clsx(
+            'text-label-xs',
+            isMobile ? 'text-content-tertiary' : 'text-content-secondary',
+          )}
+        >
+          {item.detail1?.replace('Median:', 'Med')} ·{' '}
+          {item.detail2?.replace('Std Dev:', 'SD')}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function StaffingCardShort({ item, variant }) {
+  const isMobile = variant === 'mobile';
+  return (
+    <div className="grid grid-cols-3 bg-white px-4 py-2 hover:bg-gray-50">
+      <div className="col-span-2 self-center">
+        <p
+          className={clsx(
+            'text-label-sm font-medium',
+            isMobile ? 'text-core-white' : 'text-core-black',
+          )}
+        >
+          {item.title}
+        </p>
+      </div>
+      <div className="flex flex-col items-end">
+        <p
+          className={clsx(
+            'text-label-lg font-medium',
+            isMobile ? 'text-core-white' : 'text-core-black',
+          )}
+        >
+          {item.stat}
+        </p>
+        <p
+          className={clsx(
+            'text-label-xs',
+            isMobile ? 'text-content-tertiary' : 'text-content-secondary',
+          )}
+        >
+          {item.detail?.replace('Median:', 'Med')}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 /**
  * Compact staffing metric card used in the Staffing tab grid.
  *

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -97,10 +97,16 @@ export default function OwnerNetworkContent({
             title="Clinical Quality Measures"
             variant={variant}
           >
-            <ClinicalQualityContent
-              metrics={metrics}
+            <TabbedMetricList
+              tabs={[
+                { value: 'long', label: 'Long Stay' },
+                { value: 'short', label: 'Short Stay' },
+              ]}
               activeTab={activeTab}
               setActiveTab={setActiveTab}
+              items={metrics}
+              CardComponent={MetricCardShort}
+              variant={variant}
             />
           </NetworkSidePanelAccordion>
           <NetworkSidePanelAccordion title="Staffing" variant={variant}>
@@ -160,6 +166,20 @@ function TabbedMetricList({
     </div>
   );
 }
+
+TabbedMetricList.propTypes = {
+  tabs: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  activeTab: PropTypes.string.isRequired,
+  setActiveTab: PropTypes.func.isRequired,
+  items: PropTypes.array.isRequired,
+  CardComponent: PropTypes.elementType.isRequired,
+  variant: PropTypes.oneOf(['desktop', 'mobile']),
+};
 
 OwnerNetworkContent.propTypes = {
   mode: PropTypes.oneOf(['hub', 'non-hub']).isRequired,

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -1,6 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NetworkSidePanelAccordion from './networkSidePanelAccordion';
-import { NetworkSidePanelList } from './listContainerContent';
+import {
+  MetricCardShort,
+  NetworkSidePanelList,
+  StaffingCardShort,
+} from './listContainerContent';
+import {
+  buildOwnerLongStayStats,
+  buildOwnerShortStayStats,
+} from '../../../lib/clinicalQualityMetrics';
+import {
+  buildOwnerStaffingLevels,
+  buildOwnerStaffingTurnover,
+} from '../../../lib/staffingMetrics';
 import PropTypes from 'prop-types';
 
 export default function OwnerNetworkContent({
@@ -8,8 +20,21 @@ export default function OwnerNetworkContent({
   shared,
   onSelectNode,
   variant,
+  meta,
 }) {
   const isHub = mode === 'hub';
+  const [activeTab, setActiveTab] = useState('long');
+  const [activeStaffingTab, setActiveStaffingTab] = useState('levels');
+
+  const metrics =
+    activeTab === 'long'
+      ? buildOwnerLongStayStats(meta)
+      : buildOwnerShortStayStats(meta);
+
+  const staffingMetrics =
+    activeStaffingTab === 'levels'
+      ? buildOwnerStaffingLevels(meta)
+      : buildOwnerStaffingTurnover(meta);
 
   return (
     <>
@@ -39,11 +64,24 @@ export default function OwnerNetworkContent({
             title="Clinical Quality Measures"
             variant={variant}
           >
-            {' '}
-            {/**Children */}
+            <TabbedMetricList
+              tabs={[{ value: 'long', label: 'Long Stay' }, { value: 'short', label: 'Short Stay' }]}
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+              items={metrics}
+              CardComponent={MetricCardShort}
+              variant={variant}
+            />
           </NetworkSidePanelAccordion>
           <NetworkSidePanelAccordion title="Staffing" variant={variant}>
-            {/**Children */}{' '}
+            <TabbedMetricList
+              tabs={[{ value: 'levels', label: 'Levels' }, { value: 'turnover', label: 'Turnover' }]}
+              activeTab={activeStaffingTab}
+              setActiveTab={setActiveStaffingTab}
+              items={staffingMetrics}
+              CardComponent={StaffingCardShort}
+              variant={variant}
+            />
           </NetworkSidePanelAccordion>
         </>
       ) : (
@@ -52,11 +90,21 @@ export default function OwnerNetworkContent({
             title="Clinical Quality Measures"
             variant={variant}
           >
-            {' '}
-            {/**Children */}
+            <ClinicalQualityContent
+              metrics={metrics}
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            />
           </NetworkSidePanelAccordion>
           <NetworkSidePanelAccordion title="Staffing" variant={variant}>
-            {/**Children */}{' '}
+            <TabbedMetricList
+              tabs={[{ value: 'levels', label: 'Levels' }, { value: 'turnover', label: 'Turnover' }]}
+              activeTab={activeStaffingTab}
+              setActiveTab={setActiveStaffingTab}
+              items={staffingMetrics}
+              CardComponent={StaffingCardShort}
+              variant={variant}
+            />
           </NetworkSidePanelAccordion>
         </>
       )}
@@ -64,8 +112,40 @@ export default function OwnerNetworkContent({
   );
 }
 
+function TabbedMetricList({ tabs, activeTab, setActiveTab, items, CardComponent, variant }) {
+  return (
+    <div>
+      <div className="flex border-b border-gray-200 px-4 pt-1 pb-2">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.value}
+            onClick={() => setActiveTab(tab.value)}
+            className={`rounded px-3 py-1 text-sm font-medium ${i < tabs.length - 1 ? 'mr-2' : ''} ${
+              activeTab === tab.value
+                ? 'bg-core-black text-core-white'
+                : 'text-content-secondary'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="max-h-64 overflow-y-auto">
+        <ul>
+          {items.map((item) => (
+            <li key={item.id}>
+              <CardComponent item={item} variant={variant} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
 OwnerNetworkContent.propTypes = {
   mode: PropTypes.oneOf(['hub', 'non-hub']).isRequired,
+  meta: PropTypes.object,
   shared: PropTypes.arrayOf(
     PropTypes.shape({
       ownerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
@@ -81,5 +161,6 @@ OwnerNetworkContent.propTypes = {
 
 OwnerNetworkContent.defaultProps = {
   shared: [],
+  meta: null,
   onSelectNode: undefined,
 };

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -39,91 +39,57 @@ export default function OwnerNetworkContent({
 
   return (
     <>
-      {isHub ? (
-        <>
-          <NetworkSidePanelAccordion
-            title="Ownership Relations Count"
-            defaultOpen
-            variant={variant}
-          >
-            {/**Children */}
-            <div className="max-h-64 overflow-y-auto">
-              <ul className="mt-2 rounded-lg">
-                {shared.map((owner) => (
-                  <li key={owner.ownerId}>
-                    <NetworkSidePanelList
-                      item={owner}
-                      onSelectNode={onSelectNode}
-                      variant={variant}
-                    />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </NetworkSidePanelAccordion>
-          <NetworkSidePanelAccordion
-            title="Clinical Quality Measures"
-            variant={variant}
-          >
-            <TabbedMetricList
-              tabs={[
-                { value: 'long', label: 'Long Stay' },
-                { value: 'short', label: 'Short Stay' },
-              ]}
-              activeTab={activeTab}
-              setActiveTab={setActiveTab}
-              items={metrics}
-              CardComponent={MetricCardShort}
-              variant={variant}
-            />
-          </NetworkSidePanelAccordion>
-          <NetworkSidePanelAccordion title="Staffing" variant={variant}>
-            <TabbedMetricList
-              tabs={[
-                { value: 'levels', label: 'Levels' },
-                { value: 'turnover', label: 'Turnover' },
-              ]}
-              activeTab={activeStaffingTab}
-              setActiveTab={setActiveStaffingTab}
-              items={staffingMetrics}
-              CardComponent={StaffingCardShort}
-              variant={variant}
-            />
-          </NetworkSidePanelAccordion>
-        </>
-      ) : (
-        <>
-          <NetworkSidePanelAccordion
-            title="Clinical Quality Measures"
-            variant={variant}
-          >
-            <TabbedMetricList
-              tabs={[
-                { value: 'long', label: 'Long Stay' },
-                { value: 'short', label: 'Short Stay' },
-              ]}
-              activeTab={activeTab}
-              setActiveTab={setActiveTab}
-              items={metrics}
-              CardComponent={MetricCardShort}
-              variant={variant}
-            />
-          </NetworkSidePanelAccordion>
-          <NetworkSidePanelAccordion title="Staffing" variant={variant}>
-            <TabbedMetricList
-              tabs={[
-                { value: 'levels', label: 'Levels' },
-                { value: 'turnover', label: 'Turnover' },
-              ]}
-              activeTab={activeStaffingTab}
-              setActiveTab={setActiveStaffingTab}
-              items={staffingMetrics}
-              CardComponent={StaffingCardShort}
-              variant={variant}
-            />
-          </NetworkSidePanelAccordion>
-        </>
+      {isHub && (
+        <NetworkSidePanelAccordion
+          title="Ownership Relations Count"
+          defaultOpen
+          variant={variant}
+        >
+          <div className="max-h-64 overflow-y-auto">
+            <ul aria-label="Ownership relations" className="mt-2 rounded-lg">
+              {shared.map((owner) => (
+                <li key={owner.ownerId}>
+                  <NetworkSidePanelList
+                    item={owner}
+                    onSelectNode={onSelectNode}
+                    variant={variant}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </NetworkSidePanelAccordion>
       )}
+      <NetworkSidePanelAccordion
+        title="Clinical Quality Measures"
+        defaultOpen={!isHub}
+        variant={variant}
+      >
+        <TabbedMetricList
+          tabs={[
+            { value: 'long', label: 'Long Stay' },
+            { value: 'short', label: 'Short Stay' },
+          ]}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          items={metrics}
+          CardComponent={MetricCardShort}
+          variant={variant}
+        />
+      </NetworkSidePanelAccordion>
+      <NetworkSidePanelAccordion title="Staffing" variant={variant}>
+        <TabbedMetricList
+          tabs={[
+            { value: 'levels', label: 'Levels' },
+            { value: 'turnover', label: 'Turnover' },
+          ]}
+          activeTab={activeStaffingTab}
+          setActiveTab={setActiveStaffingTab}
+          items={staffingMetrics}
+          CardComponent={StaffingCardShort}
+          variant={variant}
+        />
+      </NetworkSidePanelAccordion>
     </>
   );
 }
@@ -136,12 +102,22 @@ function TabbedMetricList({
   CardComponent,
   variant,
 }) {
+  const panelId = `tabpanel-${tabs[0]?.value}-${activeTab}`;
+
   return (
     <div className="bg-white">
-      <div className="border-border-primary flex gap-2 border-b px-4 py-2">
+      <div
+        role="tablist"
+        aria-label="Metric category"
+        className="border-border-primary flex gap-2 border-b px-4 py-2"
+      >
         {tabs.map((tab) => (
           <button
             key={tab.value}
+            role="tab"
+            aria-selected={activeTab === tab.value}
+            aria-controls={panelId}
+            tabIndex={activeTab === tab.value ? 0 : -1}
             onClick={() => setActiveTab(tab.value)}
             className={clsx(
               'text-label-xs border-border-primary text-core-black flex-1 rounded-md border py-1 transition hover:cursor-pointer',
@@ -154,8 +130,13 @@ function TabbedMetricList({
           </button>
         ))}
       </div>
-      <div className="max-h-64 overflow-y-auto">
-        <ul>
+      <div
+        id={panelId}
+        role="tabpanel"
+        aria-label={tabs.find((t) => t.value === activeTab)?.label}
+        className="max-h-64 overflow-y-auto"
+      >
+        <ul aria-label="Metrics">
           {items.map((item) => (
             <li key={item.id}>
               <CardComponent item={item} variant={variant} />

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -53,7 +53,7 @@ export default function OwnerNetworkContent({
   }[activeFinancialTab];
 
   return (
-    <>
+    <div className="flex-1 min-h-0 overflow-y-auto">
       {isHub && (
         <NetworkSidePanelAccordion
           title="Ownership Relations Count"
@@ -120,7 +120,7 @@ export default function OwnerNetworkContent({
           variant={variant}
         />
       </NetworkSidePanelAccordion>
-    </>
+    </div>
   );
 }
 

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -14,6 +14,7 @@ import {
   buildOwnerStaffingTurnover,
 } from '../../../lib/staffingMetrics';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 
 export default function OwnerNetworkContent({
   mode,
@@ -65,7 +66,10 @@ export default function OwnerNetworkContent({
             variant={variant}
           >
             <TabbedMetricList
-              tabs={[{ value: 'long', label: 'Long Stay' }, { value: 'short', label: 'Short Stay' }]}
+              tabs={[
+                { value: 'long', label: 'Long Stay' },
+                { value: 'short', label: 'Short Stay' },
+              ]}
               activeTab={activeTab}
               setActiveTab={setActiveTab}
               items={metrics}
@@ -75,7 +79,10 @@ export default function OwnerNetworkContent({
           </NetworkSidePanelAccordion>
           <NetworkSidePanelAccordion title="Staffing" variant={variant}>
             <TabbedMetricList
-              tabs={[{ value: 'levels', label: 'Levels' }, { value: 'turnover', label: 'Turnover' }]}
+              tabs={[
+                { value: 'levels', label: 'Levels' },
+                { value: 'turnover', label: 'Turnover' },
+              ]}
               activeTab={activeStaffingTab}
               setActiveTab={setActiveStaffingTab}
               items={staffingMetrics}
@@ -98,7 +105,10 @@ export default function OwnerNetworkContent({
           </NetworkSidePanelAccordion>
           <NetworkSidePanelAccordion title="Staffing" variant={variant}>
             <TabbedMetricList
-              tabs={[{ value: 'levels', label: 'Levels' }, { value: 'turnover', label: 'Turnover' }]}
+              tabs={[
+                { value: 'levels', label: 'Levels' },
+                { value: 'turnover', label: 'Turnover' },
+              ]}
               activeTab={activeStaffingTab}
               setActiveTab={setActiveStaffingTab}
               items={staffingMetrics}
@@ -112,19 +122,27 @@ export default function OwnerNetworkContent({
   );
 }
 
-function TabbedMetricList({ tabs, activeTab, setActiveTab, items, CardComponent, variant }) {
+function TabbedMetricList({
+  tabs,
+  activeTab,
+  setActiveTab,
+  items,
+  CardComponent,
+  variant,
+}) {
   return (
-    <div>
-      <div className="flex border-b border-gray-200 px-4 pt-1 pb-2">
-        {tabs.map((tab, i) => (
+    <div className="bg-white">
+      <div className="border-border-primary flex gap-2 border-b px-4 py-2">
+        {tabs.map((tab) => (
           <button
             key={tab.value}
             onClick={() => setActiveTab(tab.value)}
-            className={`rounded px-3 py-1 text-sm font-medium ${i < tabs.length - 1 ? 'mr-2' : ''} ${
+            className={clsx(
+              'text-label-xs border-border-primary text-core-black flex-1 rounded-md border py-1 transition hover:cursor-pointer',
               activeTab === tab.value
-                ? 'bg-core-black text-core-white'
-                : 'text-content-secondary'
-            }`}
+                ? 'bg-zinc-200'
+                : 'bg-zinc-100 hover:bg-zinc-50',
+            )}
           >
             {tab.label}
           </button>

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -139,7 +139,7 @@ function TabbedMetricList({
   );
 
   return (
-    <div className="bg-white">
+    <div className={variant === 'mobile' ? 'bg-zinc-900' : 'bg-white'}>
       <div
         role="tablist"
         aria-label="Metric category"

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import NetworkSidePanelAccordion from './networkSidePanelAccordion';
 import {
   MetricCardShort,
@@ -23,6 +23,21 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import useTabKeyNavigation from '../../../hooks/useTabKeyNavigation';
 
+/**
+ * Scrollable content body for a selected owner node in the network graph.
+ *
+ * Responsibilities:
+ * - Renders Ownership Relations Count accordion for hub nodes only
+ * - Renders Clinical Quality Measures, Staffing, and Financial Overview
+ *   accordions for all nodes, each with tabbed sub-categories
+ * - Passes `variant` down so cards adapt between desktop and mobile styles
+ *
+ * Notes:
+ * - Hub nodes open the Ownership Relations accordion by default; non-hub nodes
+ *   open Clinical Quality Measures by default instead.
+ * - `meta` is the raw node metadata from the graph API; builders derive display
+ *   values from it. If `meta` is null all values render as N/A.
+ */
 export default function OwnerNetworkContent({
   mode,
   shared,
@@ -35,25 +50,27 @@ export default function OwnerNetworkContent({
   const [activeStaffingTab, setActiveStaffingTab] = useState('levels');
   const [activeFinancialTab, setActiveFinancialTab] = useState('profit');
 
-  const metrics = {
+  // Memoized by `meta` so builders don't re-run on unrelated re-renders.
+  const allMetrics = useMemo(() => ({
     long: buildOwnerLongStayStats(meta),
     short: buildOwnerShortStayStats(meta),
-  }[activeTab];
+  }), [meta]);
 
-  const staffingMetrics = {
+  const allStaffingMetrics = useMemo(() => ({
     levels: buildOwnerStaffingLevels(meta),
     turnover: buildOwnerStaffingTurnover(meta),
-  }[activeStaffingTab];
+  }), [meta]);
 
-  const financialMetrics = {
+  const allFinancialMetrics = useMemo(() => ({
     profit: buildOwnerProfitStats(meta),
     revenue: buildOwnerRevenueStats(meta),
     expenses: buildOwnerExpensesStats(meta),
     liquidity: buildOwnerLiquidityStats(meta),
-  }[activeFinancialTab];
+  }), [meta]);
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto">
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* Hub only: list of co-owned facilities shared with other operators. */}
       {isHub && (
         <NetworkSidePanelAccordion
           title="Ownership Relations Count"
@@ -75,6 +92,8 @@ export default function OwnerNetworkContent({
           </div>
         </NetworkSidePanelAccordion>
       )}
+
+      {/* Non-hub nodes open CQM by default; hub nodes collapse it to save space. */}
       <NetworkSidePanelAccordion
         title="Clinical Quality Measures"
         defaultOpen={!isHub}
@@ -87,11 +106,12 @@ export default function OwnerNetworkContent({
           ]}
           activeTab={activeTab}
           setActiveTab={setActiveTab}
-          items={metrics}
+          items={allMetrics[activeTab]}
           CardComponent={MetricCardShort}
           variant={variant}
         />
       </NetworkSidePanelAccordion>
+
       <NetworkSidePanelAccordion title="Staffing" variant={variant}>
         <TabbedMetricList
           tabs={[
@@ -100,11 +120,12 @@ export default function OwnerNetworkContent({
           ]}
           activeTab={activeStaffingTab}
           setActiveTab={setActiveStaffingTab}
-          items={staffingMetrics}
+          items={allStaffingMetrics[activeStaffingTab]}
           CardComponent={StaffingCardShort}
           variant={variant}
         />
       </NetworkSidePanelAccordion>
+
       <NetworkSidePanelAccordion title="Financial Overview" variant={variant}>
         <TabbedMetricList
           tabs={[
@@ -115,7 +136,7 @@ export default function OwnerNetworkContent({
           ]}
           activeTab={activeFinancialTab}
           setActiveTab={setActiveFinancialTab}
-          items={financialMetrics}
+          items={allFinancialMetrics[activeFinancialTab]}
           CardComponent={MetricCardShort}
           variant={variant}
         />
@@ -124,6 +145,19 @@ export default function OwnerNetworkContent({
   );
 }
 
+/**
+ * Reusable tabbed list used by each metric accordion section.
+ *
+ * Responsibilities:
+ * - Renders a fully accessible ARIA tablist with roving tabindex keyboard nav
+ * - Swaps the visible card list when the active tab changes
+ * - Accepts a `CardComponent` prop so callers control the card layout
+ *
+ * Notes:
+ * - `panelId` is derived from the first tab's value so it stays stable across
+ *   tab switches — changing it would break the aria-controls association.
+ * - Keyboard navigation (Arrow keys, Home, End) is handled by useTabKeyNavigation.
+ */
 function TabbedMetricList({
   tabs,
   activeTab,
@@ -132,10 +166,10 @@ function TabbedMetricList({
   CardComponent,
   variant,
 }) {
-  const panelId = `tabpanel-${tabs[0]?.value}-${activeTab}`;
-  const { tabRefs, handleKeyDown } = useTabKeyNavigation(
-    tabs,
-    (nextTab) => setActiveTab(nextTab.value),
+  // Stable ID: must not include activeTab or it breaks aria-controls on every switch.
+  const panelId = `tabpanel-${tabs[0]?.value}`;
+  const { tabRefs, handleKeyDown } = useTabKeyNavigation(tabs, (nextTab) =>
+    setActiveTab(nextTab.value),
   );
 
   return (
@@ -148,7 +182,9 @@ function TabbedMetricList({
         {tabs.map((tab, index) => (
           <button
             key={tab.value}
-            ref={(el) => { tabRefs.current[index] = el; }}
+            ref={(el) => {
+              tabRefs.current[index] = el;
+            }}
             role="tab"
             aria-selected={activeTab === tab.value}
             aria-controls={panelId}

--- a/src/components/ui/molecule/ownerNetworkContent.jsx
+++ b/src/components/ui/molecule/ownerNetworkContent.jsx
@@ -13,8 +13,15 @@ import {
   buildOwnerStaffingLevels,
   buildOwnerStaffingTurnover,
 } from '../../../lib/staffingMetrics';
+import {
+  buildOwnerProfitStats,
+  buildOwnerRevenueStats,
+  buildOwnerExpensesStats,
+  buildOwnerLiquidityStats,
+} from '../../../lib/financialMetrics';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import useTabKeyNavigation from '../../../hooks/useTabKeyNavigation';
 
 export default function OwnerNetworkContent({
   mode,
@@ -26,16 +33,24 @@ export default function OwnerNetworkContent({
   const isHub = mode === 'hub';
   const [activeTab, setActiveTab] = useState('long');
   const [activeStaffingTab, setActiveStaffingTab] = useState('levels');
+  const [activeFinancialTab, setActiveFinancialTab] = useState('profit');
 
-  const metrics =
-    activeTab === 'long'
-      ? buildOwnerLongStayStats(meta)
-      : buildOwnerShortStayStats(meta);
+  const metrics = {
+    long: buildOwnerLongStayStats(meta),
+    short: buildOwnerShortStayStats(meta),
+  }[activeTab];
 
-  const staffingMetrics =
-    activeStaffingTab === 'levels'
-      ? buildOwnerStaffingLevels(meta)
-      : buildOwnerStaffingTurnover(meta);
+  const staffingMetrics = {
+    levels: buildOwnerStaffingLevels(meta),
+    turnover: buildOwnerStaffingTurnover(meta),
+  }[activeStaffingTab];
+
+  const financialMetrics = {
+    profit: buildOwnerProfitStats(meta),
+    revenue: buildOwnerRevenueStats(meta),
+    expenses: buildOwnerExpensesStats(meta),
+    liquidity: buildOwnerLiquidityStats(meta),
+  }[activeFinancialTab];
 
   return (
     <>
@@ -90,6 +105,21 @@ export default function OwnerNetworkContent({
           variant={variant}
         />
       </NetworkSidePanelAccordion>
+      <NetworkSidePanelAccordion title="Financial Overview" variant={variant}>
+        <TabbedMetricList
+          tabs={[
+            { value: 'profit', label: 'Profit' },
+            { value: 'revenue', label: 'Revenue' },
+            { value: 'expenses', label: 'Expenses' },
+            { value: 'liquidity', label: 'Liquidity' },
+          ]}
+          activeTab={activeFinancialTab}
+          setActiveTab={setActiveFinancialTab}
+          items={financialMetrics}
+          CardComponent={MetricCardShort}
+          variant={variant}
+        />
+      </NetworkSidePanelAccordion>
     </>
   );
 }
@@ -103,6 +133,10 @@ function TabbedMetricList({
   variant,
 }) {
   const panelId = `tabpanel-${tabs[0]?.value}-${activeTab}`;
+  const { tabRefs, handleKeyDown } = useTabKeyNavigation(
+    tabs,
+    (nextTab) => setActiveTab(nextTab.value),
+  );
 
   return (
     <div className="bg-white">
@@ -111,14 +145,16 @@ function TabbedMetricList({
         aria-label="Metric category"
         className="border-border-primary flex gap-2 border-b px-4 py-2"
       >
-        {tabs.map((tab) => (
+        {tabs.map((tab, index) => (
           <button
             key={tab.value}
+            ref={(el) => { tabRefs.current[index] = el; }}
             role="tab"
             aria-selected={activeTab === tab.value}
             aria-controls={panelId}
             tabIndex={activeTab === tab.value ? 0 : -1}
             onClick={() => setActiveTab(tab.value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
             className={clsx(
               'text-label-xs border-border-primary text-core-black flex-1 rounded-md border py-1 transition hover:cursor-pointer',
               activeTab === tab.value
@@ -134,6 +170,7 @@ function TabbedMetricList({
         id={panelId}
         role="tabpanel"
         aria-label={tabs.find((t) => t.value === activeTab)?.label}
+        tabIndex={0}
         className="max-h-64 overflow-y-auto"
       >
         <ul aria-label="Metrics">

--- a/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import NetworkGraph from './networkGraph';
 import OwnerNetworkSearchBar from './ownerNetworkSearchBar';
 import NetworkSidePanelCardHeader from './networkSidePanelCardHeader';
@@ -43,6 +44,7 @@ export default function OwnerNetworkGraphMobileLayout({
   sheetScrollRef,
   selectedNode,
   onSelectContentNode,
+  onClose,
 }) {
   return (
     <div className="bg-core-white absolute inset-0 flex flex-col overflow-hidden shadow-xl">
@@ -83,7 +85,7 @@ export default function OwnerNetworkGraphMobileLayout({
         <div className="absolute inset-x-0 bottom-0 z-30">
           <div
             className={clsx(
-              'border-border-primary rounded-t-2xl border-t bg-zinc-900 shadow-xl',
+              'border-border-primary flex flex-col rounded-t-2xl border-t bg-zinc-900 shadow-xl',
               'overflow-hidden transition-[height] duration-300 ease-out',
               isDraggingSheet && 'transition-none',
             )}
@@ -93,13 +95,20 @@ export default function OwnerNetworkGraphMobileLayout({
             onPointerUp={onSheetPointerEnd}
             onPointerCancel={onSheetPointerEnd}
           >
-            <div className="flex touch-none justify-center pt-2 pb-2">
+            <div className="relative flex shrink-0 touch-none justify-center py-4">
               <div className="bg-content-inverse-primary h-1 w-10 rounded-full" />
+              <button
+                onClick={onClose}
+                aria-label="Close network graph"
+                className="text-content-tertiary hover:text-core-white absolute top-2 right-4"
+              >
+                <XMarkIcon className="h-7 w-7" />
+              </button>
             </div>
 
             <div
               ref={sheetScrollRef}
-              className="h-full overflow-y-auto px-4 pt-3 pb-4"
+              className="min-h-0 flex-1 overflow-y-auto px-4 pt-3 pb-4"
             >
               <div className="px-3 pb-2">
                 <OwnerNetworkSearchBar
@@ -128,6 +137,7 @@ export default function OwnerNetworkGraphMobileLayout({
                 <OwnerNetworkContent
                   mode={selectedNode.type === 'hub' ? 'hub' : 'non-hub'}
                   shared={selectedNode?.meta?.sharedFacilities ?? []}
+                  meta={selectedNode.meta}
                   onSelectNode={onSelectContentNode}
                   variant="mobile"
                 />
@@ -164,4 +174,5 @@ OwnerNetworkGraphMobileLayout.propTypes = {
   sheetScrollRef: PropTypes.shape({ current: PropTypes.any }),
   selectedNode: PropTypes.object,
   onSelectContentNode: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };

--- a/src/components/ui/molecule/ownerNetworkGraphModal.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphModal.jsx
@@ -140,6 +140,7 @@ export default function OwnerNetworkGraphModal({ isOpen, onClose, ownerId }) {
           sheetScrollRef={sheetScrollRef}
           selectedNode={effectiveSelectedNode}
           onSelectContentNode={handleSelectNode}
+          onClose={onClose}
         />
       )}
     </div>

--- a/src/components/ui/molecule/ownerNetworkSidePanel.jsx
+++ b/src/components/ui/molecule/ownerNetworkSidePanel.jsx
@@ -34,7 +34,11 @@ export default function OwnerNetworkSidePanel({
   console.log(data);
 
   return (
-    <div className="border-border-primary flex h-full min-h-0 w-[300px] shrink-0 flex-col overflow-hidden border xl:w-[375px]">
+    <div
+      role="complementary"
+      aria-label="Owner details"
+      className="border-border-primary flex h-full min-h-0 w-[300px] shrink-0 flex-col overflow-hidden border xl:w-[375px]"
+    >
       {selectedNode.type === 'hub' ? (
         <HubPanel
           selectedNode={selectedNode}

--- a/src/components/ui/molecule/ownerNetworkSidePanel.jsx
+++ b/src/components/ui/molecule/ownerNetworkSidePanel.jsx
@@ -31,8 +31,6 @@ export default function OwnerNetworkSidePanel({
 
   if (!selectedNodeId || !selectedNode) return null;
 
-  console.log(data);
-
   return (
     <div
       role="complementary"
@@ -67,7 +65,11 @@ function OwnerPanel({ selectedNode, variant }) {
         nonHub={nonHub}
         variant={variant}
       />
-      <OwnerNetworkContent mode={'non-hub'} meta={selectedNode.meta} variant={variant} />
+      <OwnerNetworkContent
+        mode={'non-hub'}
+        meta={selectedNode.meta}
+        variant={variant}
+      />
     </div>
   );
 }

--- a/src/components/ui/molecule/ownerNetworkSidePanel.jsx
+++ b/src/components/ui/molecule/ownerNetworkSidePanel.jsx
@@ -57,12 +57,11 @@ export default function OwnerNetworkSidePanel({
  * selectedNode: The resolved non-hub node to display in the panel header
  */
 function OwnerPanel({ selectedNode, variant }) {
-  const nonHub = true;
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <NetworkSidePanelCardHeader
         selectedNode={selectedNode}
-        nonHub={nonHub}
+        nonHub
         variant={variant}
       />
       <OwnerNetworkContent

--- a/src/components/ui/molecule/ownerNetworkSidePanel.jsx
+++ b/src/components/ui/molecule/ownerNetworkSidePanel.jsx
@@ -31,6 +31,8 @@ export default function OwnerNetworkSidePanel({
 
   if (!selectedNodeId || !selectedNode) return null;
 
+  console.log(data);
+
   return (
     <div className="border-border-primary flex h-full min-h-0 w-[300px] shrink-0 flex-col overflow-hidden border xl:w-[375px]">
       {selectedNode.type === 'hub' ? (
@@ -61,7 +63,7 @@ function OwnerPanel({ selectedNode, variant }) {
         nonHub={nonHub}
         variant={variant}
       />
-      <OwnerNetworkContent mode={'non-hub'} variant={variant} />
+      <OwnerNetworkContent mode={'non-hub'} meta={selectedNode.meta} variant={variant} />
     </div>
   );
 }
@@ -86,6 +88,7 @@ function HubPanel({ selectedNode, onSelectNode, variant }) {
         shared={shared}
         onSelectNode={onSelectNode}
         mode={'hub'}
+        meta={selectedNode.meta}
         variant={variant}
       />
     </div>

--- a/src/components/ui/molecule/tabsSelector.jsx
+++ b/src/components/ui/molecule/tabsSelector.jsx
@@ -1,6 +1,7 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { ChevronDownIcon } from '@heroicons/react/16/solid';
+import useTabKeyNavigation from '../../../hooks/useTabKeyNavigation';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -25,45 +26,14 @@ export default function TabsSelector({
   panelId,
   getTabId,
 }) {
-  const tabRefs = useRef([]);
+  const { tabRefs, handleKeyDown } = useTabKeyNavigation(
+    tabsData,
+    (nextTab) => onTabChange?.(nextTab),
+  );
 
   const handleClick = (tabName) => {
     const newActive = tabsData.find((tab) => tab.name === tabName);
-    if (newActive) {
-      onTabChange?.(newActive);
-    }
-  };
-
-  const handleKeyDown = (event, currentIndex) => {
-    if (!tabsData.length) return;
-
-    let nextIndex = null;
-
-    switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowDown':
-        nextIndex = (currentIndex + 1) % tabsData.length;
-        break;
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        nextIndex = (currentIndex - 1 + tabsData.length) % tabsData.length;
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = tabsData.length - 1;
-        break;
-      default:
-        return;
-    }
-
-    event.preventDefault();
-    const nextTab = tabsData[nextIndex];
-    onTabChange?.(nextTab);
-    requestAnimationFrame(() => {
-      tabRefs.current[nextIndex]?.focus();
-    });
+    if (newActive) onTabChange?.(newActive);
   };
 
   return (

--- a/src/hooks/useTabKeyNavigation.js
+++ b/src/hooks/useTabKeyNavigation.js
@@ -1,0 +1,48 @@
+import { useRef } from 'react';
+
+/**
+ * Provides roving-tabindex arrow-key navigation for a ARIA tablist.
+ *
+ * Returns:
+ * - tabRefs: ref array to attach to each tab button (tabRefs.current[index])
+ * - handleKeyDown: onKeyDown handler to attach to each tab button,
+ *   called with (event, currentIndex)
+ *
+ * Handles: ArrowRight, ArrowLeft, ArrowDown, ArrowUp, Home, End
+ */
+export default function useTabKeyNavigation(tabs, onTabChange) {
+  const tabRefs = useRef([]);
+
+  function handleKeyDown(event, currentIndex) {
+    if (!tabs.length) return;
+
+    let nextIndex = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (currentIndex + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    onTabChange(tabs[nextIndex]);
+    requestAnimationFrame(() => {
+      tabRefs.current[nextIndex]?.focus();
+    });
+  }
+
+  return { tabRefs, handleKeyDown };
+}

--- a/src/lib/clinicalQualityMetrics.js
+++ b/src/lib/clinicalQualityMetrics.js
@@ -310,6 +310,7 @@ const ownerLongStayConfig = [
     valueKey: 'cms_owner_avg_ed_visits',
     medianKey: '1.8',
     stdDevKey: '.5',
+    isRate: true,
   },
   {
     id: 15,
@@ -318,6 +319,7 @@ const ownerLongStayConfig = [
     valueKey: 'cms_owner_avg_hospitalizations',
     medianKey: '1.8',
     stdDevKey: '.5',
+    isRate: true,
   },
 ];
 
@@ -355,6 +357,10 @@ const ownerShortStayConfig = [
     stdDevKey: '.5',
   },
 ];
+
+function appendSuffix(value, suffix) {
+  return value === 'N/A' ? value : `${value}${suffix}`;
+}
 
 // Facility builders add comparison labels and benchmark details for each metric card.
 export function buildFacilityLongStayStats(
@@ -414,23 +420,33 @@ export function buildFacilityShortStayStats(
 // Owner builders return the same card structure without facility-level comparison badges.
 // Placeholder benchmark values from the owner configs are surfaced here as detail text.
 export function buildOwnerLongStayStats(metricsSource) {
-  return ownerLongStayConfig.map((metric) => ({
-    id: metric.id,
-    title: metric.title,
-    subtitle: metric.subtitle,
-    value: formatMetricValue(metricsSource?.[metric.valueKey]),
-    detail1: `Median: ${metric.medianKey}`,
-    detail2: `Std Dev: ${metric.stdDevKey}`,
-  }));
+  return ownerLongStayConfig.map((metric) => {
+    const value = formatMetricValue(metricsSource?.[metric.valueKey]);
+
+    return {
+      id: metric.id,
+      title: metric.title,
+      subtitle: metric.subtitle,
+      value,
+      displayValue: metric.isRate ? value : appendSuffix(value, '%'),
+      detail1: `Median: ${metric.medianKey}`,
+      detail2: `Std Dev: ${metric.stdDevKey}`,
+    };
+  });
 }
 
 export function buildOwnerShortStayStats(metricsSource) {
-  return ownerShortStayConfig.map((metric) => ({
-    id: metric.id,
-    title: metric.title,
-    subtitle: metric.subtitle,
-    value: formatMetricValue(metricsSource?.[metric.valueKey]),
-    detail1: `Median: ${metric.medianKey}`,
-    detail2: `Std Dev: ${metric.stdDevKey}`,
-  }));
+  return ownerShortStayConfig.map((metric) => {
+    const value = formatMetricValue(metricsSource?.[metric.valueKey]);
+
+    return {
+      id: metric.id,
+      title: metric.title,
+      subtitle: metric.subtitle,
+      value,
+      displayValue: appendSuffix(value, '%'),
+      detail1: `Median: ${metric.medianKey}`,
+      detail2: `Std Dev: ${metric.stdDevKey}`,
+    };
+  });
 }

--- a/src/lib/financialMetrics.js
+++ b/src/lib/financialMetrics.js
@@ -206,6 +206,7 @@ const ownerProfitConfig = [
     valueKey: 'cms_owner_avg_operating_margin',
     medianKey: 'N/A',
     stdDevKey: 'N/A',
+    suffix: '%',
   },
   {
     id: 2,
@@ -215,6 +216,7 @@ const ownerProfitConfig = [
     valueKey: 'cms_owner_avg_total_margin',
     medianKey: 'N/A',
     stdDevKey: 'N/A',
+    suffix: '%',
   },
   {
     id: 3,
@@ -247,7 +249,7 @@ const ownerExpensesConfig = [
     title: 'Operating Expenses',
     subtitle:
       'Total costs incurred in running day-to-day facility operations. Higher values relative to revenue may indicate financial strain.',
-    valueKey: 'null',
+    valueKey: null,
     medianKey: 'N/A',
     stdDevKey: 'N/A',
     isCurrency: true,
@@ -280,6 +282,7 @@ const ownerExpensesConfig = [
     valueKey: 'cms_owner_avg_related_to_total_exp',
     medianKey: 'N/A',
     stdDevKey: 'N/A',
+    suffix: '%',
   },
   {
     id: 5,
@@ -289,6 +292,7 @@ const ownerExpensesConfig = [
     valueKey: 'cms_owner_avg_related_to_net_exp',
     medianKey: 'N/A',
     stdDevKey: 'N/A',
+    suffix: '%',
   },
 ];
 
@@ -319,16 +323,26 @@ function buildOwnerStats(config, metricsSource) {
   const format = (metric, value) =>
     metric.isCurrency ? formatUSD(value) : formatMetricValue(value);
 
-  return config.map((metric) => ({
-    id: metric.id,
-    title: metric.title,
-    subtitle: metric.subtitle,
-    value: metric.valueKey
+  const formatDisplayValue = (metric, value) => {
+    if (value === 'N/A') return value;
+    return metric.suffix ? `${value}${metric.suffix}` : value;
+  };
+
+  return config.map((metric) => {
+    const value = metric.valueKey
       ? format(metric, metricsSource?.[metric.valueKey])
-      : 'N/A',
-    detail1: `Median: ${metric.medianKey}`,
-    detail2: `Std Dev: ${metric.stdDevKey}`,
-  }));
+      : 'N/A';
+
+    return {
+      id: metric.id,
+      title: metric.title,
+      subtitle: metric.subtitle,
+      value,
+      displayValue: formatDisplayValue(metric, value),
+      detail1: `Median: ${metric.medianKey}`,
+      detail2: `Std Dev: ${metric.stdDevKey}`,
+    };
+  });
 }
 
 export function buildOwnerProfitStats(metricsSource) {

--- a/src/lib/staffingMetrics.js
+++ b/src/lib/staffingMetrics.js
@@ -53,22 +53,25 @@ const facilityStaffingTurnoverConfig = [
     valueKey: 'nursing_turnover',
     ratingKey: 'cmpr_nursing_turnover',
     stateAvgKey: 'state_nursing_turnover',
+    suffix: '%',
   },
   {
     id: 2,
     title: 'RN Turnover',
     description: 'Total staff turnover for RN',
-    valueKey: 'N/A',
-    ratingKey: 'N/A',
+    valueKey: null,
+    ratingKey: null,
     stateAvg: 'N/A',
+    suffix: '%',
   },
   {
     id: 3,
     title: 'Administrator Turnover',
     description: 'Total staff turnover for administrative staff',
-    valueKey: 'N/A',
-    ratingKey: 'N/A',
+    valueKey: null,
+    ratingKey: null,
     stateAvg: 'N/A',
+    suffix: '%',
   },
 ];
 
@@ -96,7 +99,7 @@ const ownerStaffingLevelsConfig = [
     title: 'Nurse hours/resident/weekend',
     description:
       'Reported total nurse staffing hours per resident on the weekend.',
-    valueKey: 'N/A',
+    valueKey: null,
     median: '3',
   },
 ];
@@ -108,22 +111,36 @@ const ownerStaffingTurnoverConfig = [
     description: 'Total staff turnover for nursing staff',
     valueKey: 'cms_owner_avg_turnover',
     median: '30',
+    suffix: '%',
   },
   {
     id: 2,
     title: 'RN Turnover',
     description: 'Total staff turnover for RN',
-    valueKey: 'N/A',
+    valueKey: null,
     median: '30',
+    suffix: '%',
   },
   {
     id: 3,
     title: 'Administrator Turnover',
     description: 'Total staff turnover for administrative staff',
-    valueKey: 'N/A',
+    valueKey: null,
     median: '30',
+    suffix: '%',
   },
 ];
+
+function formatStaffingValue(metric, metricsSource) {
+  return metric.valueKey
+    ? formatMetricValue(metricsSource?.[metric.valueKey])
+    : 'N/A';
+}
+
+function formatDisplayValue(metric, value) {
+  if (value === 'N/A') return value;
+  return metric.suffix ? `${value}${metric.suffix}` : value;
+}
 
 // Facility builders add state benchmark details and comparison values for staffing cards.
 export function buildFacilityStaffingLevels(metricsSource) {
@@ -131,13 +148,14 @@ export function buildFacilityStaffingLevels(metricsSource) {
 
   return facilityStaffingLevelsConfig.map((metric) => {
     const stateAvg = formatMetricValue(metricsSource?.[metric.stateAvgKey]);
+    const stat = formatStaffingValue(metric, metricsSource);
+
     return {
       id: metric.id,
       title: metric.title,
       description: metric.description,
-      stat: metric.valueKey
-        ? formatMetricValue(metricsSource?.[metric.valueKey])
-        : 'N/A',
+      stat,
+      displayStat: formatDisplayValue(metric, stat),
       rating: metricsSource?.[metric.ratingKey] ?? null,
       detail: `${stateName} average: ${stateAvg}`,
     };
@@ -151,14 +169,15 @@ export function buildFacilityStaffingTurnover(metricsSource) {
     const stateAvg = metric.stateAvgKey
       ? formatMetricValue(metricsSource?.[metric.stateAvgKey])
       : metric.stateAvg;
+    const stat = formatStaffingValue(metric, metricsSource);
+
     return {
       id: metric.id,
       title: metric.title,
       description: metric.description,
-      stat: metric.valueKey
-        ? formatMetricValue(metricsSource?.[metric.valueKey])
-        : 'N/A',
-      rating: metric.ratingKey ? metricsSource?.[metric.ratingKey] : 'N/A',
+      stat,
+      displayStat: formatDisplayValue(metric, stat),
+      rating: metric.ratingKey ? metricsSource?.[metric.ratingKey] : null,
       detail: stateAvg ? `${stateName} average: ${stateAvg}` : 'N/A',
     };
   });
@@ -167,25 +186,31 @@ export function buildFacilityStaffingTurnover(metricsSource) {
 // Owner builders return the same staffing card shape using owner aggregate values.
 // Placeholder median values from the owner configs are surfaced here as detail text.
 export function buildOwnerStaffingLevels(metricsSource) {
-  return ownerStaffingLevelsConfig.map((metric) => ({
-    id: metric.id,
-    title: metric.title,
-    description: metric.description,
-    stat: metric.valueKey
-      ? formatMetricValue(metricsSource?.[metric.valueKey])
-      : 'N/A',
-    detail: `Median: ${metric.median}`,
-  }));
+  return ownerStaffingLevelsConfig.map((metric) => {
+    const stat = formatStaffingValue(metric, metricsSource);
+
+    return {
+      id: metric.id,
+      title: metric.title,
+      description: metric.description,
+      stat,
+      displayStat: formatDisplayValue(metric, stat),
+      detail: `Median: ${metric.median}`,
+    };
+  });
 }
 
 export function buildOwnerStaffingTurnover(metricsSource) {
-  return ownerStaffingTurnoverConfig.map((metric) => ({
-    id: metric.id,
-    title: metric.title,
-    description: metric.description,
-    stat: metric.valueKey
-      ? formatMetricValue(metricsSource?.[metric.valueKey])
-      : 'N/A',
-    detail: `Median: ${metric.median}`,
-  }));
+  return ownerStaffingTurnoverConfig.map((metric) => {
+    const stat = formatStaffingValue(metric, metricsSource);
+
+    return {
+      id: metric.id,
+      title: metric.title,
+      description: metric.description,
+      stat,
+      displayStat: formatDisplayValue(metric, stat),
+      detail: `Median: ${metric.median}`,
+    };
+  });
 }


### PR DESCRIPTION
**Summary**

- Builds out the owner network graph side panel with four data sections: Ownership Relations Count (hub nodes only), Clinical Quality Measures, Staffing, and Financial Overview — each backed by tabbed sub-categories
- Adds MetricCardShort and StaffingCardShort to listContainerContent.jsx — compact card variants designed for the narrow side panel, with abbreviated labels and right-aligned values
- Extracts a useTabKeyNavigation hook from TabsSelector and shares it across all custom tab UIs — provides full ARIA tablist keyboard support (Arrow keys, Home, End, roving tabindex) in one place rather than duplicating it per component
- Fixes mobile sheet layout so the scroll body, drag handle, and content don't overflow the sheet height
- Add "X" close button on mobile slider 
- Memoizes all metric builder calls in OwnerNetworkContent so they only re-run when the selected node changes, not on every render

**Accessibility**

- The custom tab UIs in this panel implement the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) — role="tablist", role="tab", role="tabpanel", aria-selected, aria-controls, and roving tabIndex. The keyboard behavior (ArrowLeft/ArrowRight, Home, End) was extracted into useTabKeyNavigation so it can be shared with TabsSelector and any future tab UI without duplication.