### PR TITLE
Add Operating Margin and RPTOE Node Size Filters to Network Graph

### DIFF
--- a/src/components/ui/atom/networkFilterControl.jsx
+++ b/src/components/ui/atom/networkFilterControl.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  * -value: either a number/string that describes what filter is applied
  * -active: boolean value determined by state managment
  * -onClick: sets the state
+ * -ariaLabel: optional accessible label for abbreviated button text (e.g. "RPTOE")
  *
  * Example usage {
  *  <SegmentButton
@@ -20,11 +21,13 @@ import PropTypes from 'prop-types';
  *  Future:  Add color props etc
  */
 
-export default function NetworkFilterControl({ value, active, onClick }) {
+export default function NetworkFilterControl({ value, active, onClick, ariaLabel }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active ?? false}
+      aria-label={ariaLabel}
       className={clsx(
         'text-label-xs text-core-black border-border-primary h-10 rounded-md border transition hover:cursor-pointer',
         active ? 'bg-zinc-200' : 'bg-zinc-100 hover:bg-zinc-50',
@@ -39,4 +42,5 @@ NetworkFilterControl.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   active: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
+  ariaLabel: PropTypes.string,
 };

--- a/src/components/ui/molecule/networkFilter.jsx
+++ b/src/components/ui/molecule/networkFilter.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import NetworkSidePanelAccordion from './networkSidePanelAccordion';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import InfoTooltip from '../atom/infoTooltip';
 import { Cog6ToothIcon } from '@heroicons/react/24/outline';
@@ -15,8 +14,8 @@ import NetworkFilterControl from '../atom/networkFilterControl';
  * Props:
  * -depth: tracks current depth of requested network (1 or 2)
  * -onSetDepth: used by buttons click to register a new selection in depth
- * -onSetSizeMetric:used by buttons in Node Size section to register new node size mode.
- * -sizeMetric: Tracks current node size viewing mode (default, star, opMargin, rptoe)
+ * -onSetNodeSizeMetric: used by buttons in Node Size section to register a node size mode.
+ * -nodeSizeMetric: Tracks current node size viewing mode.
  *
  * Notes:
  * - Rendered by `OwnerNetworkGraphModal`
@@ -27,8 +26,8 @@ import NetworkFilterControl from '../atom/networkFilterControl';
 export default function NetworkFilter({
   onSetDepth,
   depth,
-  onSetSizeMetric,
-  sizeMetric,
+  onSetNodeSizeMetric,
+  nodeSizeMetric,
 }) {
   return (
     <div className="lg:w-[300px] xl:w-[375px]">
@@ -71,23 +70,25 @@ export default function NetworkFilter({
           <div className="grid grid-cols-2 gap-2">
             <NetworkFilterControl
               value={'Default'}
-              active={sizeMetric === 'default'}
-              onClick={() => onSetSizeMetric('default')}
+              active={nodeSizeMetric === 'default'}
+              onClick={() => onSetNodeSizeMetric('default')}
             />
             <NetworkFilterControl
               value={'Star Rating'}
-              active={sizeMetric === 'star'}
-              onClick={() => onSetSizeMetric('star')}
+              active={nodeSizeMetric === 'starRating'}
+              onClick={() => onSetNodeSizeMetric('starRating')}
             />
             <NetworkFilterControl
               value={'Op Margin'}
-              active={sizeMetric === 'opMargin'}
-              onClick={() => onSetSizeMetric('opMargin')}
+              active={nodeSizeMetric === 'operatingMargin'}
+              onClick={() => onSetNodeSizeMetric('operatingMargin')}
             />
             <NetworkFilterControl
               value={'RPTOE'}
-              active={sizeMetric === 'rptoe'}
-              onClick={() => onSetSizeMetric('rptoe')}
+              active={nodeSizeMetric === 'relatedPartyExpenseRatio'}
+              onClick={() =>
+                onSetNodeSizeMetric('relatedPartyExpenseRatio')
+              }
               ariaLabel="Related Party to Total Operating Expenses"
             />
           </div>
@@ -100,7 +101,11 @@ export default function NetworkFilter({
 NetworkFilter.propTypes = {
   onSetDepth: PropTypes.func.isRequired,
   depth: PropTypes.oneOf([1, 2]).isRequired,
-  onSetSizeMetric: PropTypes.func.isRequired,
-  sizeMetric: PropTypes.oneOf(['default', 'star', 'opMargin', 'rptoe'])
-    .isRequired,
+  onSetNodeSizeMetric: PropTypes.func.isRequired,
+  nodeSizeMetric: PropTypes.oneOf([
+    'default',
+    'starRating',
+    'operatingMargin',
+    'relatedPartyExpenseRatio',
+  ]).isRequired,
 };

--- a/src/components/ui/molecule/networkFilter.jsx
+++ b/src/components/ui/molecule/networkFilter.jsx
@@ -16,7 +16,7 @@ import NetworkFilterControl from '../atom/networkFilterControl';
  * -depth: tracks current depth of requested network (1 or 2)
  * -onSetDepth: used by buttons click to register a new selection in depth
  * -onSetSizeMetric:used by buttons in Node Size section to register new node size mode.
- * -sizeMetric: Tracks current node size viewing mode (default, star rating, quality,    financial) 3/2/26 the last two are hypothetical at this time
+ * -sizeMetric: Tracks current node size viewing mode (default, star, opMargin, rptoe)
  *
  * Notes:
  * - Rendered by `OwnerNetworkGraphModal`
@@ -63,7 +63,7 @@ export default function NetworkFilter({
           <div className="space-y-2">
             <div className="text-label-sm text-core-black flex items-center gap-2">
               <span>Node Size</span>
-              <InfoTooltip text="Determines how node size is scaled.  Choose between uniform sizing or scaling by Star Rating, Quality, or Financial metrics." />
+              <InfoTooltip text="Determines how node size is scaled. Choose between uniform sizing or scaling by Star Rating, Operating Margin, or Related Party to Total Operating Expenses." />
             </div>
           </div>
 
@@ -88,6 +88,7 @@ export default function NetworkFilter({
               value={'RPTOE'}
               active={sizeMetric === 'rptoe'}
               onClick={() => onSetSizeMetric('rptoe')}
+              ariaLabel="Related Party to Total Operating Expenses"
             />
           </div>
         </div>

--- a/src/components/ui/molecule/networkFilter.jsx
+++ b/src/components/ui/molecule/networkFilter.jsx
@@ -80,14 +80,14 @@ export default function NetworkFilter({
               onClick={() => onSetSizeMetric('star')}
             />
             <NetworkFilterControl
-              value={'Quality'}
-              active={sizeMetric === 'quality'}
-              onClick={() => onSetSizeMetric('quality')}
+              value={'Op Margin'}
+              active={sizeMetric === 'opMargin'}
+              onClick={() => onSetSizeMetric('opMargin')}
             />
             <NetworkFilterControl
-              value={'Financial'}
-              active={sizeMetric === 'financial'}
-              onClick={() => onSetSizeMetric('financial')}
+              value={'RPTOE'}
+              active={sizeMetric === 'rptoe'}
+              onClick={() => onSetSizeMetric('rptoe')}
             />
           </div>
         </div>
@@ -100,6 +100,6 @@ NetworkFilter.propTypes = {
   onSetDepth: PropTypes.func.isRequired,
   depth: PropTypes.oneOf([1, 2]).isRequired,
   onSetSizeMetric: PropTypes.func.isRequired,
-  sizeMetric: PropTypes.oneOf(['default', 'star', 'quality', 'financial'])
+  sizeMetric: PropTypes.oneOf(['default', 'star', 'opMargin', 'rptoe'])
     .isRequired,
 };

--- a/src/components/ui/molecule/networkGraph.jsx
+++ b/src/components/ui/molecule/networkGraph.jsx
@@ -25,6 +25,7 @@ import {
  * - Filters visible neighborhoods based on the active node
  * - Builds the search index that powers the modal search dropdown
  */
+
 const sigmaStyle = { height: '100%', width: '100%' };
 
 const sharedFacilityShape = PropTypes.shape({
@@ -90,6 +91,16 @@ function buildGraph(data) {
       meta: node.meta,
       starRating: Number.isFinite(Number(node?.meta.star_rating))
         ? Number(node.meta.star_rating)
+        : null,
+      opMargin: Number.isFinite(
+        Number(node?.meta.cms_owner_avg_operating_margin),
+      )
+        ? Number(node.meta.cms_owner_avg_operating_margin)
+        : null,
+      rptoe: Number.isFinite(
+        Number(node?.meta.cms_owner_avg_related_to_total_exp),
+      )
+        ? Number(node.meta.cms_owner_avg_related_to_total_exp)
         : null,
     });
   }
@@ -225,6 +236,21 @@ function InteractionLayer({
     return min + Math.pow(t, gamma) * (max - min);
   }, []);
 
+  // operating margin: percentage scale, ≤0 = min, cap at 25%
+  const opMarginToSize = useCallback((margin) => {
+    if (margin == null || Number.isNaN(margin)) return 5;
+    if (margin <= 0) return 5;
+    const t = Math.min(1, margin / 25);
+    return 5 + t * 15;
+  }, []);
+
+  // RPTOE: percentage scale, cap at 50%
+  const rptoeToSize = useCallback((ratio) => {
+    if (ratio == null || Number.isNaN(ratio)) return 5;
+    const t = Math.min(1, Math.max(0, ratio / 50));
+    return 5 + t * 15;
+  }, []);
+
   //Shared pin function used by click + search
   const pinNode = useCallback(
     (nodeId) => {
@@ -288,6 +314,10 @@ function InteractionLayer({
         // Base size by mode
         if (sizeMetric === 'star') {
           res.size = starToSize(data.starRating);
+        } else if (sizeMetric === 'opMargin') {
+          res.size = opMarginToSize(data.opMargin);
+        } else if (sizeMetric === 'rptoe') {
+          res.size = rptoeToSize(data.rptoe);
         } else {
           // keep what buildGraph set
           res.size = data.size ?? 8;
@@ -330,7 +360,16 @@ function InteractionLayer({
         return res;
       },
     });
-  }, [setSettings, graph, activeNode, neighborSet, starToSize, sizeMetric]);
+  }, [
+    setSettings,
+    graph,
+    activeNode,
+    neighborSet,
+    starToSize,
+    opMarginToSize,
+    rptoeToSize,
+    sizeMetric,
+  ]);
 
   return null;
 }

--- a/src/components/ui/molecule/networkGraph.jsx
+++ b/src/components/ui/molecule/networkGraph.jsx
@@ -40,6 +40,8 @@ const nodeShape = PropTypes.shape({
   meta: PropTypes.shape({
     cms_ownership_type: PropTypes.string,
     star_rating: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    cms_owner_avg_operating_margin: PropTypes.number,
+    cms_owner_avg_related_to_total_exp: PropTypes.number,
     sharedFacilities: PropTypes.arrayOf(sharedFacilityShape),
   }),
 });
@@ -89,17 +91,13 @@ function buildGraph(data) {
       y: 0,
       nodeType: node.type,
       meta: node.meta,
-      starRating: Number.isFinite(Number(node?.meta.star_rating))
+      starRating: Number.isFinite(Number(node?.meta?.star_rating))
         ? Number(node.meta.star_rating)
         : null,
-      opMargin: Number.isFinite(
-        Number(node?.meta.cms_owner_avg_operating_margin),
-      )
+      opMargin: Number.isFinite(Number(node?.meta?.cms_owner_avg_operating_margin))
         ? Number(node.meta.cms_owner_avg_operating_margin)
         : null,
-      rptoe: Number.isFinite(
-        Number(node?.meta.cms_owner_avg_related_to_total_exp),
-      )
+      rptoe: Number.isFinite(Number(node?.meta?.cms_owner_avg_related_to_total_exp))
         ? Number(node.meta.cms_owner_avg_related_to_total_exp)
         : null,
     });

--- a/src/components/ui/molecule/networkGraph.jsx
+++ b/src/components/ui/molecule/networkGraph.jsx
@@ -40,8 +40,14 @@ const nodeShape = PropTypes.shape({
   meta: PropTypes.shape({
     cms_ownership_type: PropTypes.string,
     star_rating: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    cms_owner_avg_operating_margin: PropTypes.number,
-    cms_owner_avg_related_to_total_exp: PropTypes.number,
+    cms_owner_avg_operating_margin: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    cms_owner_avg_related_to_total_exp: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
     sharedFacilities: PropTypes.arrayOf(sharedFacilityShape),
   }),
 });
@@ -94,10 +100,14 @@ function buildGraph(data) {
       starRating: Number.isFinite(Number(node?.meta?.star_rating))
         ? Number(node.meta.star_rating)
         : null,
-      opMargin: Number.isFinite(Number(node?.meta?.cms_owner_avg_operating_margin))
+      operatingMargin: Number.isFinite(
+        Number(node?.meta?.cms_owner_avg_operating_margin),
+      )
         ? Number(node.meta.cms_owner_avg_operating_margin)
         : null,
-      rptoe: Number.isFinite(Number(node?.meta?.cms_owner_avg_related_to_total_exp))
+      relatedPartyExpenseRatio: Number.isFinite(
+        Number(node?.meta?.cms_owner_avg_related_to_total_exp),
+      )
         ? Number(node.meta.cms_owner_avg_related_to_total_exp)
         : null,
     });
@@ -192,13 +202,13 @@ ForceAtlasToggle.propTypes = {
  * - onPinnedChang: Called when the locked node selection changes
  * - pinRequestNodeId: Node id requested externally for pin/focus behavior
  * - onPinRequestConsumed: Clears the external pin request after it is handled
- * - sizeMetric: Controls whether nodes use default or star-based sizing
+ * - nodeSizeMetric: Controls which metric drives node sizing
  */
 function InteractionLayer({
   onPinnedChange,
   pinRequestNodeId,
   onPinRequestConsumed,
-  sizeMetric,
+  nodeSizeMetric,
 }) {
   const sigma = useSigma();
   const graph = sigma.getGraph();
@@ -219,8 +229,8 @@ function InteractionLayer({
     onPinnedChange?.(lockedNode);
   }, [lockedNode, onPinnedChange]);
 
-  //calculating star ratingto size
-  const starToSize = useCallback((star) => {
+  //calculating star rating to size
+  const starRatingToSize = useCallback((star) => {
     // fallback for unknown ratings
     if (star == null || Number.isNaN(star)) return 7;
 
@@ -235,7 +245,7 @@ function InteractionLayer({
   }, []);
 
   // operating margin: percentage scale, ≤0 = min, cap at 25%
-  const opMarginToSize = useCallback((margin) => {
+  const operatingMarginToSize = useCallback((margin) => {
     if (margin == null || Number.isNaN(margin)) return 5;
     if (margin <= 0) return 5;
     const t = Math.min(1, margin / 25);
@@ -243,7 +253,7 @@ function InteractionLayer({
   }, []);
 
   // RPTOE: percentage scale, cap at 50%
-  const rptoeToSize = useCallback((ratio) => {
+  const relatedPartyExpenseRatioToSize = useCallback((ratio) => {
     if (ratio == null || Number.isNaN(ratio)) return 5;
     const t = Math.min(1, Math.max(0, ratio / 50));
     return 5 + t * 15;
@@ -300,7 +310,7 @@ function InteractionLayer({
     return () => {
       if (container) container.style.cursor = 'default';
     };
-  }, [registerEvents, sigma, lockedNode]);
+  }, [registerEvents, sigma, lockedNode, pinNode]);
 
   // reducers: show only active + neighbors
   useEffect(() => {
@@ -310,12 +320,14 @@ function InteractionLayer({
         const res = { ...data };
 
         // Base size by mode
-        if (sizeMetric === 'star') {
-          res.size = starToSize(data.starRating);
-        } else if (sizeMetric === 'opMargin') {
-          res.size = opMarginToSize(data.opMargin);
-        } else if (sizeMetric === 'rptoe') {
-          res.size = rptoeToSize(data.rptoe);
+        if (nodeSizeMetric === 'starRating') {
+          res.size = starRatingToSize(data.starRating);
+        } else if (nodeSizeMetric === 'operatingMargin') {
+          res.size = operatingMarginToSize(data.operatingMargin);
+        } else if (nodeSizeMetric === 'relatedPartyExpenseRatio') {
+          res.size = relatedPartyExpenseRatioToSize(
+            data.relatedPartyExpenseRatio,
+          );
         } else {
           // keep what buildGraph set
           res.size = data.size ?? 8;
@@ -363,10 +375,10 @@ function InteractionLayer({
     graph,
     activeNode,
     neighborSet,
-    starToSize,
-    opMarginToSize,
-    rptoeToSize,
-    sizeMetric,
+    starRatingToSize,
+    operatingMarginToSize,
+    relatedPartyExpenseRatioToSize,
+    nodeSizeMetric,
   ]);
 
   return null;
@@ -376,7 +388,12 @@ InteractionLayer.propTypes = {
   onPinnedChange: PropTypes.func,
   pinRequestNodeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onPinRequestConsumed: PropTypes.func,
-  sizeMetric: PropTypes.string,
+  nodeSizeMetric: PropTypes.oneOf([
+    'default',
+    'starRating',
+    'operatingMargin',
+    'relatedPartyExpenseRatio',
+  ]),
 };
 
 /**
@@ -508,7 +525,7 @@ GraphSearchController.propTypes = {
  * - onSearchResults: Receives search suggestions generated from graph data
  * - pinRequestNodeId: External node id to pin from search or panel actions
  * - onPinRequestConsumed: Clears the pin request after it has been handled
- * - sizeMetric: Controls the node sizing mode
+ * - nodeSizeMetric: Controls the node sizing mode
  * - isSearchOpen: Whether the search dropdown is open
  */
 export default function NetworkGraph({
@@ -518,12 +535,12 @@ export default function NetworkGraph({
   onSearchResults,
   pinRequestNodeId,
   onPinRequestConsumed,
-  sizeMetric,
+  nodeSizeMetric,
   isSearchOpen,
   showFullScreenControl = true,
 }) {
   //fallback for setting node size mode
-  const effectiveSizeMetric = sizeMetric ?? 'default';
+  const effectiveNodeSizeMetric = nodeSizeMetric ?? 'default';
   //if you need to set the background color of the graph it is done in tailwind.css
   return (
     <SigmaContainer
@@ -538,7 +555,7 @@ export default function NetworkGraph({
         onPinnedChange={onSelectNode}
         pinRequestNodeId={pinRequestNodeId}
         onPinRequestConsumed={onPinRequestConsumed}
-        sizeMetric={effectiveSizeMetric}
+        nodeSizeMetric={effectiveNodeSizeMetric}
       />
       <GraphSearchController
         searchQuery={searchQuery}
@@ -560,7 +577,12 @@ NetworkGraph.propTypes = {
   onSearchResults: PropTypes.func,
   pinRequestNodeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onPinRequestConsumed: PropTypes.func,
-  sizeMetric: PropTypes.string,
+  nodeSizeMetric: PropTypes.oneOf([
+    'default',
+    'starRating',
+    'operatingMargin',
+    'relatedPartyExpenseRatio',
+  ]),
   isSearchOpen: PropTypes.bool,
   showFullScreenControl: PropTypes.bool,
 };

--- a/src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx
@@ -32,10 +32,10 @@ export default function OwnerNetworkGraphDesktopLayout({
   pinRequestNodeId,
   onPinRequestConsumed,
   onSearchResults,
-  sizeMetric,
+  nodeSizeMetric,
   onSetDepth,
   depth,
-  onSetSizeMetric,
+  onSetNodeSizeMetric,
   selectedNodeId,
   onClearSelection,
   onSelectSidePanelNode,
@@ -57,8 +57,8 @@ export default function OwnerNetworkGraphDesktopLayout({
           <NetworkFilter
             onSetDepth={onSetDepth}
             depth={depth}
-            onSetSizeMetric={onSetSizeMetric}
-            sizeMetric={sizeMetric}
+            onSetNodeSizeMetric={onSetNodeSizeMetric}
+            nodeSizeMetric={nodeSizeMetric}
           />
         </div>
 
@@ -89,7 +89,7 @@ export default function OwnerNetworkGraphDesktopLayout({
                 onPinRequestConsumed={onPinRequestConsumed}
                 searchQuery={searchQuery}
                 onSearchResults={onSearchResults}
-                sizeMetric={sizeMetric}
+                nodeSizeMetric={nodeSizeMetric}
                 isSearchOpen={isSearchOpen}
               />
             </div>
@@ -122,10 +122,15 @@ OwnerNetworkGraphDesktopLayout.propTypes = {
   pinRequestNodeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onPinRequestConsumed: PropTypes.func.isRequired,
   onSearchResults: PropTypes.func.isRequired,
-  sizeMetric: PropTypes.string.isRequired,
+  nodeSizeMetric: PropTypes.oneOf([
+    'default',
+    'starRating',
+    'operatingMargin',
+    'relatedPartyExpenseRatio',
+  ]).isRequired,
   onSetDepth: PropTypes.func.isRequired,
   depth: PropTypes.number.isRequired,
-  onSetSizeMetric: PropTypes.func.isRequired,
+  onSetNodeSizeMetric: PropTypes.func.isRequired,
   selectedNodeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClearSelection: PropTypes.func.isRequired,
   onSelectSidePanelNode: PropTypes.func.isRequired,

--- a/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
@@ -28,7 +28,7 @@ export default function OwnerNetworkGraphMobileLayout({
   onPinRequestConsumed,
   searchQuery,
   onSearchResults,
-  sizeMetric,
+  nodeSizeMetric,
   isSearchOpen,
   onSetSearchQuery,
   searchResults,
@@ -73,7 +73,7 @@ export default function OwnerNetworkGraphMobileLayout({
               onPinRequestConsumed={onPinRequestConsumed}
               searchQuery={searchQuery}
               onSearchResults={onSearchResults}
-              sizeMetric={sizeMetric}
+              nodeSizeMetric={nodeSizeMetric}
               isSearchOpen={isSearchOpen}
               showFullScreenControl={false}
             />
@@ -149,7 +149,12 @@ OwnerNetworkGraphMobileLayout.propTypes = {
   onPinRequestConsumed: PropTypes.func.isRequired,
   searchQuery: PropTypes.string.isRequired,
   onSearchResults: PropTypes.func.isRequired,
-  sizeMetric: PropTypes.string.isRequired,
+  nodeSizeMetric: PropTypes.oneOf([
+    'default',
+    'starRating',
+    'operatingMargin',
+    'relatedPartyExpenseRatio',
+  ]).isRequired,
   isSearchOpen: PropTypes.bool.isRequired,
   onSetSearchQuery: PropTypes.func.isRequired,
   searchResults: PropTypes.array.isRequired,

--- a/src/components/ui/molecule/ownerNetworkGraphModal.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphModal.jsx
@@ -39,7 +39,7 @@ export default function OwnerNetworkGraphModal({ isOpen, onClose, ownerId }) {
     status,
     error,
     depth,
-    sizeMetric,
+    nodeSizeMetric,
     searchQuery,
     searchResults,
     pinRequestNodeId,
@@ -47,7 +47,7 @@ export default function OwnerNetworkGraphModal({ isOpen, onClose, ownerId }) {
     effectiveSelectedNodeId,
     effectiveSelectedNode,
     setDepth,
-    setSizeMetric,
+    setNodeSizeMetric,
     setSearchQuery,
     setSearchResults,
     setSelectedNodeId,
@@ -107,10 +107,10 @@ export default function OwnerNetworkGraphModal({ isOpen, onClose, ownerId }) {
           pinRequestNodeId={pinRequestNodeId}
           onPinRequestConsumed={handlePinRequestConsumed}
           onSearchResults={setSearchResults}
-          sizeMetric={sizeMetric}
+          nodeSizeMetric={nodeSizeMetric}
           onSetDepth={setDepth}
           depth={depth}
-          onSetSizeMetric={setSizeMetric}
+          onSetNodeSizeMetric={setNodeSizeMetric}
           selectedNodeId={effectiveSelectedNodeId}
           onClearSelection={handleClearSelection}
           onSelectSidePanelNode={handleSelectNode}
@@ -125,7 +125,7 @@ export default function OwnerNetworkGraphModal({ isOpen, onClose, ownerId }) {
           onPinRequestConsumed={handlePinRequestConsumed}
           searchQuery={searchQuery}
           onSearchResults={setSearchResults}
-          sizeMetric={sizeMetric}
+          nodeSizeMetric={nodeSizeMetric}
           isSearchOpen={isSearchOpen}
           onSetSearchQuery={setSearchQuery}
           searchResults={searchResults}

--- a/src/hooks/useOwnerNetworkGraphController.js
+++ b/src/hooks/useOwnerNetworkGraphController.js
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
  * - data fetch lifecycle (idle/loading/ready/error)
  * - selection + pin request coordination
  * - search query / search results state
- * - graph filter controls (depth, size metric)
+ * - graph filter controls (depth, node size metric)
  */
 export default function useOwnerNetworkGraphController({ isOpen, ownerId }) {
   const API_BASE_URL =
@@ -22,7 +22,7 @@ export default function useOwnerNetworkGraphController({ isOpen, ownerId }) {
   // Shared graph UI state.
   const [selectedNodeId, setSelectedNodeId] = useState(null);
   const [depth, setDepth] = useState(2);
-  const [sizeMetric, setSizeMetric] = useState('default');
+  const [nodeSizeMetric, setNodeSizeMetric] = useState('default');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [pinRequestNodeId, setPinRequestNodeId] = useState(null);
@@ -117,7 +117,7 @@ export default function useOwnerNetworkGraphController({ isOpen, ownerId }) {
     status,
     error,
     depth,
-    sizeMetric,
+    nodeSizeMetric,
     searchQuery,
     searchResults,
     pinRequestNodeId,
@@ -125,7 +125,7 @@ export default function useOwnerNetworkGraphController({ isOpen, ownerId }) {
     effectiveSelectedNodeId,
     effectiveSelectedNode,
     setDepth,
-    setSizeMetric,
+    setNodeSizeMetric,
     setSearchQuery,
     setSearchResults,
     setSelectedNodeId,


### PR DESCRIPTION
We add two new node size metrics to the graph filter panel, replacing the previous placeholder Quality and Financial buttons.

**Changes**
networkGraph.jsx — extracts operatingMargin and relatedPartyExpenseRatio from node meta in buildGraph; adds operatingMarginToSize and relatedPartyExpenseRatioToSize helpers; branches the nodeReducer for each new metric; hardens all meta reads with optional chaining; updated PropTypes throughout

networkFilter.jsx — replaces placeholder buttons with Op Margin and RPTOE; updated tooltip text and prop comment

networkFilterControl.jsx — adds aria-pressed and optional ariaLabel prop for accessibility

ownerNetworkGraphDesktopLayout.jsx — updated PropTypes to match narrowed oneOf values

**Accessibility**
All filter buttons now expose aria-pressed so screen readers can announce active state
RPTOE button includes aria-label="Related Party to Total Operating Expenses" since the abbreviation is opaque