### PR TITLE
Add skeletons

### DIFF
--- a/src/components/ui/atom/skeletons.jsx
+++ b/src/components/ui/atom/skeletons.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 function SkeletonBar({ className = '' }) {
   return <div className={`animate-pulse rounded bg-gray-200 ${className}`} />;
 }
@@ -51,18 +53,119 @@ export function ProfilePageSkeleton() {
       <div className="mt-6 space-y-4">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
+            <div
+              key={i}
+              className="space-y-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
+            >
               <SkeletonBar className="h-4 w-1/2" />
               <SkeletonBar className="h-8 w-1/3" />
               <SkeletonBar className="h-3 w-3/4" />
             </div>
           ))}
         </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
+        <div className="space-y-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
           <SkeletonBar className="h-4 w-1/4" />
           <SkeletonBar className="h-4 w-full" />
           <SkeletonBar className="h-4 w-5/6" />
         </div>
+      </div>
+    </div>
+  );
+}
+
+// Nodes and edges for the animated graph placeholder. Positions are expressed
+// as percentages of the SVG viewBox (0 0 400 300) so it scales to any canvas.
+const GRAPH_NODES = [
+  { id: 'hub', cx: 200, cy: 150, r: 14 },
+  { id: 'a',   cx: 310, cy:  80, r:  8 },
+  { id: 'b',   cx: 340, cy: 175, r:  8 },
+  { id: 'c',   cx: 270, cy: 255, r:  8 },
+  { id: 'd',   cx: 130, cy: 255, r:  8 },
+  { id: 'e',   cx:  90, cy: 165, r:  8 },
+  { id: 'f',   cx: 140, cy:  75, r:  8 },
+  { id: 'g',   cx: 310, cy: 220, r:  6 },
+  { id: 'h',   cx:  95, cy: 100, r:  6 },
+];
+
+const GRAPH_EDGES = [
+  ['hub', 'a'], ['hub', 'b'], ['hub', 'c'],
+  ['hub', 'd'], ['hub', 'e'], ['hub', 'f'],
+  ['b',   'g'], ['e',   'h'], ['a',   'f'],
+];
+
+function nodePos(id) {
+  return GRAPH_NODES.find((n) => n.id === id);
+}
+
+function GraphSVG({ className = '' }) {
+  return (
+    <svg viewBox="0 0 400 300" className={className} aria-hidden="true">
+      <style>{`
+        @keyframes graphPulse {
+          0%, 100% { opacity: 0.3; }
+          50%       { opacity: 0.9; }
+        }
+        .gp-edge     { animation: graphPulse 2s ease-in-out infinite; }
+        .gp-node     { animation: graphPulse 2s ease-in-out infinite; }
+        .gp-node-hub { animation: graphPulse 1.6s ease-in-out infinite; }
+      `}</style>
+      {GRAPH_EDGES.map(([from, to]) => {
+        const s = nodePos(from);
+        const t = nodePos(to);
+        return (
+          <line
+            key={`${from}-${to}`}
+            x1={s.cx} y1={s.cy} x2={t.cx} y2={t.cy}
+            stroke="#D1D5DB" strokeWidth="1.5" className="gp-edge"
+            style={{ animationDelay: `${Math.random() * 0.8}s` }}
+          />
+        );
+      })}
+      {GRAPH_NODES.map((n) => (
+        <circle
+          key={n.id} cx={n.cx} cy={n.cy} r={n.r}
+          fill={n.id === 'hub' ? '#FCD34D' : '#9CA3AF'}
+          className={n.id === 'hub' ? 'gp-node-hub' : 'gp-node'}
+          style={{ animationDelay: `${Math.random() * 0.8}s` }}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function NetworkGraphSkeleton() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-gray-50">
+      <GraphSVG className="w-[520px] opacity-50" />
+      <p className="animate-pulse text-base text-gray-500" role="status">Loading network...</p>
+    </div>
+  );
+}
+
+export function NetworkSidePanelSkeleton() {
+  return (
+    <div className="border-border-primary flex h-full w-[300px] shrink-0 flex-col overflow-hidden border xl:w-[375px]">
+      {/* Header bar */}
+      <div className="bg-border-secondary border-border-primary flex h-14 items-center justify-between border-b px-4">
+        <SkeletonBar className="h-4 w-24" />
+        <SkeletonBar className="h-5 w-20 rounded-full" />
+      </div>
+      {/* Name + meta */}
+      <div className="space-y-2 px-4 pt-3 pb-2">
+        <SkeletonBar className="h-5 w-3/4" />
+        <SkeletonBar className="h-3 w-1/3" />
+        <div className="border-t border-gray-200 pt-2">
+          <SkeletonBar className="h-4 w-28" />
+        </div>
+      </div>
+      {/* Content rows */}
+      <div className="flex-1 space-y-3 px-4 pt-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between">
+            <SkeletonBar className="h-4 w-2/3" />
+            <SkeletonBar className="h-4 w-10" />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/ui/atom/skeletons.jsx
+++ b/src/components/ui/atom/skeletons.jsx
@@ -1,0 +1,18 @@
+function SkeletonBar({ className = '' }) {
+  return (
+    <div className={`animate-pulse rounded bg-gray-200 ${className}`} />
+  );
+}
+
+export function IndustryListSkeleton() {
+  return (
+    <ul className="divide-y divide-gray-200 rounded-xl border border-l-2 border-gray-200 bg-white/80">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <li key={i} className="flex items-center justify-between px-6 py-6">
+          <SkeletonBar className="h-4 w-40" />
+          <SkeletonBar className="h-4 w-20" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/atom/skeletons.jsx
+++ b/src/components/ui/atom/skeletons.jsx
@@ -27,6 +27,47 @@ export function BrowseListSkeleton({ count = 10 }) {
   );
 }
 
+export function ProfilePageSkeleton() {
+  return (
+    <div className="animate-pulse font-sans">
+      {/* ProfileHeader */}
+      <div className="my-6 flex flex-wrap justify-between">
+        <div>
+          <SkeletonBar className="h-9 w-80" />
+          <div className="mt-4">
+            <SkeletonBar className="h-6 w-32 rounded-full" />
+          </div>
+          <SkeletonBar className="mt-4 h-4 w-48" />
+        </div>
+        <SkeletonBar className="h-10 w-36 rounded-lg" />
+      </div>
+      {/* Tab nav */}
+      <div className="mt-6 flex gap-4 border-b border-gray-200 pb-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonBar key={i} className="h-5 w-28" />
+        ))}
+      </div>
+      {/* Tab content area */}
+      <div className="mt-6 space-y-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
+              <SkeletonBar className="h-4 w-1/2" />
+              <SkeletonBar className="h-8 w-1/3" />
+              <SkeletonBar className="h-3 w-3/4" />
+            </div>
+          ))}
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm space-y-3">
+          <SkeletonBar className="h-4 w-1/4" />
+          <SkeletonBar className="h-4 w-full" />
+          <SkeletonBar className="h-4 w-5/6" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function IndustryListSkeleton() {
   return (
     <ul className="divide-y divide-gray-200 rounded-xl border border-l-2 border-gray-200 bg-white/80">

--- a/src/components/ui/atom/skeletons.jsx
+++ b/src/components/ui/atom/skeletons.jsx
@@ -1,6 +1,29 @@
 function SkeletonBar({ className = '' }) {
+  return <div className={`animate-pulse rounded bg-gray-200 ${className}`} />;
+}
+
+export function BrowseListSkeleton({ count = 10 }) {
   return (
-    <div className={`animate-pulse rounded bg-gray-200 ${className}`} />
+    <ul>
+      {Array.from({ length: count }).map((_, i) => (
+        <li
+          key={i}
+          className="bg-core-white border-border-primary mb-3 overflow-hidden rounded-xl border px-4 py-4 shadow-sm sm:px-6"
+        >
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="space-y-2 md:col-span-2">
+              <SkeletonBar className="h-5 w-3/4" />
+              <SkeletonBar className="h-4 w-1/2" />
+              <SkeletonBar className="h-4 w-2/5" />
+            </div>
+            <div className="space-y-2">
+              <SkeletonBar className="h-4 w-full" />
+              <SkeletonBar className="h-4 w-3/4" />
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/components/ui/atom/skeletons.jsx
+++ b/src/components/ui/atom/skeletons.jsx
@@ -1,9 +1,22 @@
 import React from 'react';
 
+/**
+ * Skeleton loading components for data-dependent UI sections.
+ *
+ * Each skeleton mirrors the layout of its target component so the page
+ * structure stays stable while data is in flight. All skeletons use
+ * Tailwind's animate-pulse utility for the shimmer effect, with the
+ * exception of the network graph which uses a custom SVG pulse animation
+ * to better communicate that a graph is loading.
+ *
+ * Add new skeletons here and include a comment indicating where each is used.
+ */
+
 function SkeletonBar({ className = '' }) {
   return <div className={`animate-pulse rounded bg-gray-200 ${className}`} />;
 }
 
+// Used in: src/components/ui/organism/browsePage.jsx
 export function BrowseListSkeleton({ count = 10 }) {
   return (
     <ul>
@@ -29,6 +42,7 @@ export function BrowseListSkeleton({ count = 10 }) {
   );
 }
 
+// Used in: src/pages/FacilityProfile.jsx, src/pages/OwnersProfile.jsx
 export function ProfilePageSkeleton() {
   return (
     <div className="animate-pulse font-sans">
@@ -77,20 +91,26 @@ export function ProfilePageSkeleton() {
 // as percentages of the SVG viewBox (0 0 400 300) so it scales to any canvas.
 const GRAPH_NODES = [
   { id: 'hub', cx: 200, cy: 150, r: 14 },
-  { id: 'a',   cx: 310, cy:  80, r:  8 },
-  { id: 'b',   cx: 340, cy: 175, r:  8 },
-  { id: 'c',   cx: 270, cy: 255, r:  8 },
-  { id: 'd',   cx: 130, cy: 255, r:  8 },
-  { id: 'e',   cx:  90, cy: 165, r:  8 },
-  { id: 'f',   cx: 140, cy:  75, r:  8 },
-  { id: 'g',   cx: 310, cy: 220, r:  6 },
-  { id: 'h',   cx:  95, cy: 100, r:  6 },
+  { id: 'a', cx: 310, cy: 80, r: 8 },
+  { id: 'b', cx: 340, cy: 175, r: 8 },
+  { id: 'c', cx: 270, cy: 255, r: 8 },
+  { id: 'd', cx: 130, cy: 255, r: 8 },
+  { id: 'e', cx: 90, cy: 165, r: 8 },
+  { id: 'f', cx: 140, cy: 75, r: 8 },
+  { id: 'g', cx: 310, cy: 220, r: 6 },
+  { id: 'h', cx: 95, cy: 100, r: 6 },
 ];
 
 const GRAPH_EDGES = [
-  ['hub', 'a'], ['hub', 'b'], ['hub', 'c'],
-  ['hub', 'd'], ['hub', 'e'], ['hub', 'f'],
-  ['b',   'g'], ['e',   'h'], ['a',   'f'],
+  ['hub', 'a'],
+  ['hub', 'b'],
+  ['hub', 'c'],
+  ['hub', 'd'],
+  ['hub', 'e'],
+  ['hub', 'f'],
+  ['b', 'g'],
+  ['e', 'h'],
+  ['a', 'f'],
 ];
 
 function nodePos(id) {
@@ -115,15 +135,23 @@ function GraphSVG({ className = '' }) {
         return (
           <line
             key={`${from}-${to}`}
-            x1={s.cx} y1={s.cy} x2={t.cx} y2={t.cy}
-            stroke="#D1D5DB" strokeWidth="1.5" className="gp-edge"
+            x1={s.cx}
+            y1={s.cy}
+            x2={t.cx}
+            y2={t.cy}
+            stroke="#D1D5DB"
+            strokeWidth="1.5"
+            className="gp-edge"
             style={{ animationDelay: `${Math.random() * 0.8}s` }}
           />
         );
       })}
       {GRAPH_NODES.map((n) => (
         <circle
-          key={n.id} cx={n.cx} cy={n.cy} r={n.r}
+          key={n.id}
+          cx={n.cx}
+          cy={n.cy}
+          r={n.r}
           fill={n.id === 'hub' ? '#FCD34D' : '#9CA3AF'}
           className={n.id === 'hub' ? 'gp-node-hub' : 'gp-node'}
           style={{ animationDelay: `${Math.random() * 0.8}s` }}
@@ -133,15 +161,19 @@ function GraphSVG({ className = '' }) {
   );
 }
 
+// Used in: src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx, src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
 export function NetworkGraphSkeleton() {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-gray-50">
-      <GraphSVG className="w-[520px] opacity-50" />
-      <p className="animate-pulse text-base text-gray-500" role="status">Loading network...</p>
+      <GraphSVG className="w-[280px] opacity-50 sm:w-[520px]" />
+      <p className="animate-pulse text-base text-gray-500" role="status">
+        Loading network...
+      </p>
     </div>
   );
 }
 
+// Used in: src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx
 export function NetworkSidePanelSkeleton() {
   return (
     <div className="border-border-primary flex h-full w-[300px] shrink-0 flex-col overflow-hidden border xl:w-[375px]">
@@ -171,6 +203,7 @@ export function NetworkSidePanelSkeleton() {
   );
 }
 
+// Used in: src/pages/Home.jsx
 export function IndustryListSkeleton() {
   return (
     <ul className="divide-y divide-gray-200 rounded-xl border border-l-2 border-gray-200 bg-white/80">

--- a/src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphDesktopLayout.jsx
@@ -4,6 +4,10 @@ import OwnerNetworkGraphNav from './ownerNetworkGraphNav';
 import NetworkFilter from './networkFilter';
 import NetworkGraph from './networkGraph';
 import OwnerNetworkSidePanel from './ownerNetworkSidePanel';
+import {
+  NetworkGraphSkeleton,
+  NetworkSidePanelSkeleton,
+} from '../atom/skeletons.jsx';
 
 /**
  * Desktop presentation shell for the Owner Network Graph modal.
@@ -63,8 +67,11 @@ export default function OwnerNetworkGraphDesktopLayout({
         </div>
 
         {status === 'loading' && (
-          <div className="absolute inset-0 grid place-items-center">
-            <div className="text-sm text-gray-600">Loading graph...</div>
+          <div className="flex h-full min-h-0">
+            <div className="relative min-w-0 flex-1">
+              <NetworkGraphSkeleton />
+            </div>
+            <NetworkSidePanelSkeleton />
           </div>
         )}
 

--- a/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
+++ b/src/components/ui/molecule/ownerNetworkGraphMobileLayout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import NetworkGraph from './networkGraph';
 import OwnerNetworkSearchBar from './ownerNetworkSearchBar';
+import { NetworkGraphSkeleton } from '../atom/skeletons.jsx';
 import NetworkSidePanelCardHeader from './networkSidePanelCardHeader';
 import OwnerNetworkContent from './ownerNetworkContent';
 
@@ -47,11 +48,7 @@ export default function OwnerNetworkGraphMobileLayout({
   return (
     <div className="bg-core-white absolute inset-0 flex flex-col overflow-hidden shadow-xl">
       <div className="relative min-h-0 flex-1">
-        {status === 'loading' && (
-          <div className="absolute inset-0 grid place-items-center">
-            <div className="text-sm text-gray-600">Loading graph...</div>
-          </div>
-        )}
+        {status === 'loading' && <NetworkGraphSkeleton />}
 
         {status === 'error' && (
           <div className="absolute inset-0 grid place-items-center px-6 text-center">

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import BrowseListView from './browseListView';
 import PropTypes from 'prop-types';
+import { BrowseListSkeleton } from '../atom/skeletons.jsx';
 
 /**
  * This component controls fetching data and search suggestions
@@ -119,9 +120,7 @@ export default function BrowsePage({
             did not return any results.
           </p>
         ) : null}
-        {loading && (
-          <p className="text-sm text-gray-500">Loading new page...</p>
-        )}
+        {loading && <BrowseListSkeleton />}
         {error && <p>Error: {error.message}</p>}
       </BrowseListView>
     </div>

--- a/src/pages/FacilityProfile.jsx
+++ b/src/pages/FacilityProfile.jsx
@@ -16,6 +16,7 @@ import ClinicalQualityTab from '../components/ui/molecule/tabs/clinicalQualityTa
 import StaffingTab from '../components/ui/molecule/tabs/staffingTab';
 import FinancialOverviewTab from '../components/ui/molecule/tabs/financialOverviewTab';
 import { Heading } from '../components/ui/atom/heading';
+import { ProfilePageSkeleton } from '../components/ui/atom/skeletons.jsx';
 import ListContainer, {
   ListContainerDivider,
 } from '../components/ui/organism/ListContainer';
@@ -65,17 +66,10 @@ export default function FacilityProfile() {
     fetchNationalBenchmarks();
   }, []);
 
-  if (loading) {
-    return (
-      <p role="status" aria-live="polite">
-        Loading facility details...
-      </p>
-    );
-  }
-  if (!facility) return <p role="alert">Facility not found.</p>;
+  if (!facility && !loading) return <p role="alert">Facility not found.</p>;
 
   // Relationship records used for stakeholders + ownership diagram sections.
-  const ownershipLinks = facility.facility_ownership_links || [];
+  const ownershipLinks = facility?.facility_ownership_links || [];
 
   //click handler to open the AI chat
   const handleResearchClick = () => {
@@ -86,6 +80,7 @@ export default function FacilityProfile() {
     <main className="bg-background-secondary font-sans">
       <Breadcrumb />
       <LayoutPage>
+        {loading ? <ProfilePageSkeleton /> : <>
         <ProfileHeader
           title={facility.provider_name}
           ownershipType={facility.ownership_type}
@@ -166,6 +161,7 @@ export default function FacilityProfile() {
         <div className={ownershipLinks.length > 0 ? 'pb-8' : 'pt-8 pb-8'}>
           <AdditionalInformation items={facility} />
         </div>
+        </>}
       </LayoutPage>
     </main>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,6 +11,7 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/24/outline';
 import MonthlyOwnershipChangeChart from '../components/ui/organism/monthlyOwnershipChangeChart.jsx';
+import { IndustryListSkeleton } from '../components/ui/atom/skeletons.jsx';
 
 export default function Home() {
   const [topChains, setTopChains] = useState([]);
@@ -115,18 +116,16 @@ export default function Home() {
           <Heading level={2} className="text-heading-lg my-6 text-center">
             State of the Nursing Home Industry
           </Heading>
-          {loading ? (
-            <p className="text-center text-gray-500">
-              Loading industry data...
-            </p>
-          ) : error ? (
-            <p className="text-center text-red-600">{error}</p>
-          ) : (
-            <div className="grid grid-cols-1 gap-8 pt-4 md:grid-cols-2">
-              <div>
-                <Heading level={3} className="mb-4">
-                  Top 10 Largest Chains
-                </Heading>
+          <div className="grid grid-cols-1 gap-8 pt-4 md:grid-cols-2">
+            <div>
+              <Heading level={3} className="mb-4">
+                Top 10 Largest Chains
+              </Heading>
+              {loading ? (
+                <IndustryListSkeleton />
+              ) : error ? (
+                <p className="text-red-600">{error}</p>
+              ) : (
                 <ul className="divide-y divide-gray-200 rounded-xl border border-l-2 border-gray-200 bg-white/80 shadow-[0_1px_6px_0_rgba(59,130,246,0.07)]">
                   {topChains.map((chain) => (
                     <li key={chain.name}>
@@ -145,11 +144,17 @@ export default function Home() {
                     </li>
                   ))}
                 </ul>
-              </div>
-              <div>
-                <Heading level={3} className="mb-4">
-                  Top 10 Largest Individual Owners
-                </Heading>
+              )}
+            </div>
+            <div>
+              <Heading level={3} className="mb-4">
+                Top 10 Largest Individual Owners
+              </Heading>
+              {loading ? (
+                <IndustryListSkeleton />
+              ) : error ? (
+                <p className="text-red-600">{error}</p>
+              ) : (
                 <ul className="divide-y divide-gray-200 rounded-xl border border-l-2 border-gray-200 bg-white/80 shadow-[0_1px_6px_0_rgba(168,85,247,0.07)]">
                   {topOwners.map((owner) => (
                     <Link
@@ -171,9 +176,9 @@ export default function Home() {
                     </Link>
                   ))}
                 </ul>
-              </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
       </section>
       {/* Barchart Graphic Section */}

--- a/src/pages/OwnersProfile.jsx
+++ b/src/pages/OwnersProfile.jsx
@@ -11,6 +11,7 @@ import { ListContainerDivider } from '../components/ui/organism/ListContainer';
 import { RelatedFacilities } from '../components/ui/molecule/listContainerContent';
 import { getBadgeColorOwnerProfile } from '../lib/getBadgeColor';
 import { toTitleCase } from '../lib/toTitleCase';
+import { ProfilePageSkeleton } from '../components/ui/atom/skeletons.jsx';
 import OwnersNetworkGraphLauncher from '../components/ui/molecule/ownerNetworkGraphLauncher';
 import TabsShell from '../components/ui/molecule/tabsShell';
 import { profileTabsDescriptions } from '../lib/tabDescriptions';
@@ -49,18 +50,11 @@ export default function OwnersProfile() {
       .finally(() => setLoading(false));
   }, [slug]);
 
-  if (loading) {
-    return (
-      <p role="status" aria-live="polite">
-        Loading owner details...
-      </p>
-    );
-  }
-  if (!owner) return <p role="alert">Owner not found.</p>;
+  if (!owner && !loading) return <p role="alert">Owner not found.</p>;
 
   // Use related facilities from API if available
   const relatedFacilities =
-    owner.facility_ownership_links?.map((link) => ({
+    owner?.facility_ownership_links?.map((link) => ({
       ...link.facility,
       cms_ownership_role: link.cms_ownership_role,
     })) || [];
@@ -77,6 +71,7 @@ export default function OwnersProfile() {
     <main className="bg-background-secondary">
       <Breadcrumb />
       <LayoutPage>
+        {loading ? <ProfilePageSkeleton /> : <>
         <ProfileHeader
           title={toTitleCase(owner.cms_ownership_name)}
           ownershipType={owner.cms_ownership_type}
@@ -142,6 +137,7 @@ export default function OwnersProfile() {
             </button>
           </div>
         )}
+        </>}
       </LayoutPage>
     </main>
   );


### PR DESCRIPTION
## Summary

This PR adds loading skeleton components across all data-dependent pages and UI sections, replacing plain text loading states with structured shimmer placeholders that match the real layout.

### Architecture

All skeletons live in a single file: `src/components/ui/atom/skeletons.jsx`

This keeps skeleton components centralized and easy to find. Each skeleton is a named export used directly in the component that owns the loading state. A file-level comment documents the pattern and each skeleton has an inline comment pointing to where it is consumed.

### Skeletons added

- **`IndustryListSkeleton`** — used in `Home.jsx` for the Top 10 Chains and Top 10 Owners lists. Section headings render immediately since they are static; only the lists are gated on the fetch.
- **`BrowseListSkeleton`** — used in `browsePage.jsx` for the facilities and owners browse pages. Renders 10 card-shaped rows matching the ListContainerSeparate layout.
- **`ProfilePageSkeleton`** — shared between `FacilityProfile.jsx` and `OwnersProfile.jsx`. Mirrors the profile header, tab nav, and tab content area. The breadcrumb renders immediately in both pages since it is navigation, not content.
- **`NetworkGraphSkeleton`** — used in both desktop and mobile network graph layouts. An animated SVG placeholder with a hub-and-spoke node layout, sized responsively (280px mobile / 520px desktop). Uses a custom CSS pulse animation to communicate that a graph is loading, with a pulsing "Loading network..." label.
- **`NetworkSidePanelSkeleton`** — used in the desktop network graph layout alongside the graph skeleton. Mirrors the side panel structure at its fixed width. Desktop only — mobile handles its own layout via the bottom sheet.
