### PR TITLE
Hefti researcher cta

### DIFF
--- a/src/components/ui/molecule/heftiResearcherCTA.jsx
+++ b/src/components/ui/molecule/heftiResearcherCTA.jsx
@@ -3,34 +3,25 @@ import PropTypes from 'prop-types';
 import { SparklesIcon } from '@heroicons/react/20/solid';
 
 /**
- * HeftiResearcherCTA
- *
- * A call-to-action button displayed on the Owner Profile page.
- * When clicked, it opens the HEFTI Researcher AI chat panel.
- *
- * Note the border is actually just a background in order to implement the gradient border effect
- *
- * On hover the button raises 1 px, cursor pointer, and bg is slightly blue.
- *
- * Props:
- *  - onClick: function — opens the chat panel
+ * CTA button for the HEFTI Researcher AI chat.
+ * The gradient border is a background on the outer button with padding acting as border thickness.
+ * Animation and fallback styles live in tailwind.css under `.hefti-cta-border`.
  */
-
 export default function HeftiResearcherCTA({ onClick }) {
   return (
+    // Outer element is the visible gradient border — padding = border thickness.
+    // focus-visible ring only shows on keyboard nav, not mouse click.
     <button
       onClick={onClick}
-      className="group max-w-[270px] rounded-xl bg-linear-to-r from-blue-600 via-blue-400 to-cyan-300 p-[1.5px] transition-all duration-200 ease-out hover:-translate-y-px hover:cursor-pointer hover:shadow-sm"
+      className="hefti-cta-border group max-w-[270px] rounded-xl p-[2.5px] transition-all duration-200 ease-out hover:-translate-y-px hover:cursor-pointer hover:shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
       aria-label="Open HEFTI Researcher AI chat"
     >
-      <div className="flex gap-2 rounded-xl bg-white p-2 text-left transition-colors duration-200 group-hover:bg-[#f8fbff]">
-        {/* Sparkle / AI icon */}
+      {/* Inner div sits on top of the gradient background, creating the border illusion */}
+      <div className="flex gap-2 rounded-[10.5px] bg-white p-2 text-left transition-colors duration-200 group-hover:bg-[#f8fbff]">
         <SparklesIcon
-          className="size-5 text-blue-600 transition-colors group-hover:text-blue-600"
+          className="size-5 shrink-0 text-blue-600"
           aria-hidden="true"
         />
-
-        {/* Label */}
         <p className="text-label-xs text-core-black">
           HEFTI Researcher{' '}
           <span className="text-xs font-normal">

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -57,6 +57,32 @@
   background-color: #ffffff !important;
 }
 
+/* HeftiResearcherCTA spinning gradient border — static linear-gradient as fallback,
+   animated conic-gradient for browsers that support @property + conic-gradient. */
+@property --hefti-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+@keyframes hefti-spin {
+  to { --hefti-angle: 360deg; }
+}
+.hefti-cta-border {
+  background: linear-gradient(135deg, #2563EB, #60A5FA, #67E8F9);
+}
+@supports (background: conic-gradient(from 1deg, red, blue)) {
+  .hefti-cta-border {
+    animation: hefti-spin 4s linear infinite;
+    background: conic-gradient(
+      from var(--hefti-angle),
+      #2563EB,
+      #60A5FA,
+      #67E8F9,
+      #2563EB
+    );
+  }
+}
+
 /*Fallback Overrides for Older Browsers */
 @supports not (color: oklch(0% 0 0)) {
   @import './fallback-legacy.css';


### PR DESCRIPTION
Animate HeftiResearcherCTA gradient border with browser fallback  //ask by Rahul

- Replaces static Tailwind gradient border with an animated spinning conic-gradient
- Adds static linear-gradient fallback for browsers without @property/conic-gradient support
- Adds focus-visible outline for keyboard accessibility