### PR TITLE
Add Recharts visualizations to researcher right panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.6.1",
+        "recharts": "^3.8.1",
         "sigma": "^3.0.2"
       },
       "devDependencies": {
@@ -1478,6 +1479,42 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1815,6 +1852,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@storybook/addon-actions": {
       "version": "8.6.14",
@@ -2837,6 +2886,12 @@
       "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-format": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
@@ -2895,6 +2950,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
       "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -3046,6 +3107,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -4598,6 +4665,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
@@ -4686,6 +4762,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4756,6 +4841,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -5235,6 +5326,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -5589,6 +5690,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6359,6 +6466,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -9259,6 +9376,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -9348,6 +9488,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9399,6 +9569,21 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9477,6 +9662,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10489,7 +10680,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -11012,6 +11202,58 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.1",
+    "recharts": "^3.8.1",
     "sigma": "^3.0.2"
   },
   "devDependencies": {

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ScatterChart,
+  Scatter,
+  ResponsiveContainer,
+} from 'recharts';
+
+const COLORS = [
+  '#2563eb',
+  '#16a34a',
+  '#dc2626',
+  '#d97706',
+  '#7c3aed',
+  '#0891b2',
+];
+
+function ChartWrapper({ title, description, children }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 p-4">
+      <p className="text-paragraph-sm text-core-black font-semibold">{title}</p>
+      {description && (
+        <p className="text-paragraph-sm text-content-secondary mt-1">
+          {description}
+        </p>
+      )}
+      <div className="mt-4">{children}</div>
+    </div>
+  );
+}
+
+function BarView({ data }) {
+  const bars = data.bars ?? data.items ?? [];
+  const normalized = bars.map((b) => ({
+    label: b.label ?? b.name,
+    value: b.value,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart
+        data={normalized}
+        margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: '#71717a' }}
+          angle={-35}
+          textAnchor="end"
+          interval={0}
+        />
+        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <Tooltip />
+        <Bar dataKey="value" fill={COLORS[0]} radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ComparisonBarView({ data }) {
+  const { categories = [], series = [] } = data;
+  const normalized = categories.map((cat, i) => {
+    const row = { category: cat };
+    series.forEach((s) => {
+      row[s.name] = s.values?.[i] ?? s.data?.[i];
+    });
+    return row;
+  });
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart
+        data={normalized}
+        margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <XAxis
+          dataKey="category"
+          tick={{ fontSize: 11, fill: '#71717a' }}
+          angle={-35}
+          textAnchor="end"
+          interval={0}
+        />
+        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <Tooltip />
+        <Legend />
+        {series.map((s, i) => (
+          <Bar
+            key={s.name}
+            dataKey={s.name}
+            fill={COLORS[i % COLORS.length]}
+            radius={[3, 3, 0, 0]}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function ScatterView({ data }) {
+  const points = data.points ?? [];
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <ScatterChart margin={{ top: 4, right: 8, left: 0, bottom: 8 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <XAxis
+          dataKey="x"
+          name={data.xLabel ?? 'x'}
+          tick={{ fontSize: 11, fill: '#71717a' }}
+        />
+        <YAxis
+          dataKey="y"
+          name={data.yLabel ?? 'y'}
+          tick={{ fontSize: 11, fill: '#71717a' }}
+        />
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+        <Scatter data={points} fill={COLORS[0]} />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+}
+
+function DistributionView({ data }) {
+  const bins = data.bins ?? data.bars ?? data.items ?? [];
+  const normalized = bins.map((b) => ({
+    label: b.range ?? b.label ?? b.name,
+    value: b.count ?? b.value,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart
+        data={normalized}
+        margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: '#71717a' }}
+          angle={-35}
+          textAnchor="end"
+          interval={0}
+        />
+        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <Tooltip />
+        <Bar dataKey="value" fill={COLORS[1]} radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function KpiRowView({ data }) {
+  const kpis = data.kpis ?? [];
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {kpis.map((kpi, i) => (
+        <div key={i} className="rounded-lg bg-zinc-50 p-3">
+          <p className="text-xs text-zinc-500">{kpi.label}</p>
+          <p className="mt-1 text-xl font-semibold text-zinc-900">
+            {kpi.value}
+            {kpi.unit ? (
+              <span className="ml-1 text-sm font-normal text-zinc-500">
+                {kpi.unit}
+              </span>
+            ) : null}
+          </p>
+          {kpi.delta && (
+            <p className="mt-0.5 text-xs text-zinc-400">{kpi.delta}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TableView({ data }) {
+  const rows = data.rows ?? [];
+  if (!rows.length) return null;
+
+  // rows can be array-of-arrays (with a separate columns array)
+  // or array-of-objects (columns derived from keys)
+  const isArrayRows = Array.isArray(rows[0]);
+  const columns = isArrayRows
+    ? (data.columns ?? rows[0].map((_, i) => String(i)))
+    : Object.keys(rows[0]);
+
+  const getCell = (row, col, i) =>
+    isArrayRows ? (row[i] ?? '—') : (row[col] ?? '—');
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-xs">
+        <thead>
+          <tr className="border-b border-zinc-200">
+            {columns.map((col) => (
+              <th
+                key={col}
+                className="pr-4 pb-2 font-semibold whitespace-nowrap text-zinc-500 capitalize"
+              >
+                {String(col).replace(/_/g, ' ')}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-b border-zinc-100 last:border-0">
+              {columns.map((col, j) => (
+                <td key={col} className="py-2 pr-4 whitespace-nowrap text-zinc-800">
+                  {getCell(row, col, j)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const VIEWS = {
+  bar: BarView,
+  comparison_bar: ComparisonBarView,
+  scatter: ScatterView,
+  distribution: DistributionView,
+  kpi_row: KpiRowView,
+  table: TableView,
+};
+
+export default function ResearchChart({ chart }) {
+  const { chart_type, title, description, data } = chart;
+  const View = VIEWS[chart_type];
+  if (!View) return null;
+  return (
+    <ChartWrapper title={title} description={description}>
+      <View data={data} />
+    </ChartWrapper>
+  );
+}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -7,6 +7,7 @@ import ReactMarkdown from 'react-markdown';
 import { MdComponents } from '../lib/mdComponents';
 import { getResearchPages } from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
+import ResearchChart from '../components/ui/molecule/ResearchChart';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
@@ -144,6 +145,8 @@ export default function HeftiResearch() {
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
+      let finalText = '';
+      const finalCharts = [];
 
       while (true) {
         const { done, value } = await reader.read();
@@ -166,6 +169,7 @@ export default function HeftiResearch() {
           }
 
           if (text) {
+            finalText += text;
             setMessages((prev) =>
               prev.map((m) =>
                 m.id === assistantMessage.id
@@ -176,10 +180,13 @@ export default function HeftiResearch() {
           }
 
           if (chart) {
+            finalCharts.push(chart);
             setCharts((prev) => [...prev, chart]);
           }
         }
       }
+
+      console.log('[researcher] final response:', { text: finalText, charts: finalCharts });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
     }
@@ -276,15 +283,7 @@ export default function HeftiResearch() {
         <section className="flex min-h-0 flex-col bg-white">
           <div className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
             {charts.map((chart, i) => (
-              <div key={i} className="rounded-xl border border-zinc-200 p-4">
-                <p className="text-paragraph-sm font-semibold text-core-black">{chart.title}</p>
-                {chart.description && (
-                  <p className="text-paragraph-sm text-content-secondary mt-1">{chart.description}</p>
-                )}
-                <pre className="mt-3 overflow-x-auto rounded bg-zinc-50 p-3 text-xs text-zinc-600">
-                  {JSON.stringify(chart.data, null, 2)}
-                </pre>
-              </div>
+              <ResearchChart key={i} chart={chart} />
             ))}
           </div>
         </section>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -41,6 +41,7 @@ export default function HeftiResearch() {
 
   const [prompt, setPrompt] = useState('');
   const [messages, setMessages] = useState([]);
+  const [charts, setCharts] = useState([]);
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
@@ -84,6 +85,8 @@ export default function HeftiResearch() {
       content: '',
       isError: false,
     };
+
+    setCharts([]);
 
     // flushSync forces React to commit the new messages to the DOM synchronously
     // before we proceed. Without this, the requestAnimationFrame below would run
@@ -155,7 +158,7 @@ export default function HeftiResearch() {
           const payload = line.slice(6);
           if (payload === '[DONE]') break;
 
-          const { text, error } = JSON.parse(payload);
+          const { text, error, chart } = JSON.parse(payload);
 
           if (error) {
             setError(error);
@@ -170,6 +173,10 @@ export default function HeftiResearch() {
                   : m,
               ),
             );
+          }
+
+          if (chart) {
+            setCharts((prev) => [...prev, chart]);
           }
         }
       }
@@ -265,9 +272,21 @@ export default function HeftiResearch() {
           </div>
         </section>
 
-        {/**Right-Panel Images and Export */}
+        {/* Right panel — chart output */}
         <section className="flex min-h-0 flex-col bg-white">
-          <div className="mr-auto flex h-full w-full max-w-[600px] flex-col"></div>
+          <div className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
+            {charts.map((chart, i) => (
+              <div key={i} className="rounded-xl border border-zinc-200 p-4">
+                <p className="text-paragraph-sm font-semibold text-core-black">{chart.title}</p>
+                {chart.description && (
+                  <p className="text-paragraph-sm text-content-secondary mt-1">{chart.description}</p>
+                )}
+                <pre className="mt-3 overflow-x-auto rounded bg-zinc-50 p-3 text-xs text-zinc-600">
+                  {JSON.stringify(chart.data, null, 2)}
+                </pre>
+              </div>
+            ))}
+          </div>
         </section>
       </div>
     </>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -147,24 +147,32 @@ export default function HeftiResearch() {
       const decoder = new TextDecoder();
       let finalText = '';
       const finalCharts = [];
+      let lineBuffer = '';
+      let done = false;
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+      while (!done) {
+        const { done: streamDone, value } = await reader.read();
+        done = streamDone;
 
-        const chunk = decoder.decode(value);
-        const lines = chunk
-          .split('\n')
-          .filter((line) => line.startsWith('data: '));
+        // Accumulate into a line buffer so SSE lines split across TCP chunks are
+        // reassembled before parsing. Without this, large chart payloads cause
+        // JSON.parse failures when the chunk boundary falls mid-line.
+        lineBuffer += decoder.decode(value ?? new Uint8Array(), { stream: !done });
+
+        const lines = lineBuffer.split('\n');
+        // Keep the last (potentially incomplete) segment in the buffer
+        lineBuffer = lines.pop();
 
         for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
           const payload = line.slice(6);
-          if (payload === '[DONE]') break;
+          if (payload === '[DONE]') { done = true; break; }
 
           const { text, error, chart } = JSON.parse(payload);
 
           if (error) {
             setError(error);
+            done = true;
             break;
           }
 


### PR DESCRIPTION
**### Summary**

- Wires render_chart SSE events from the researcher stream to the right panel, replacing the raw JSON placeholder
- Adds a ResearchChart component that handles all 6 chart types defined by the backend tool schema: bar, comparison_bar, scatter, distribution, kpi_row, and table
- Fixes a bug where large chart JSON payloads could be split across TCP chunks, causing JSON.parse failures — solved with a line buffer that reassembles incomplete SSE lines before parsing