### PR TITLE
Implement sort fields  **MERGE FIRST** 1/2

### DIFF
--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -814,6 +814,12 @@ NetworkSidePanelList.propTypes = {
  * Expected item shape:
  * - rank: number (1-based position)
  * - name: state name string
+ *
+ * Props:
+ * - to: optional URL string; when provided, renders the state name as a link
+ *   to the facilities browse page pre-filtered by state and sort.
+ *   The link passes router state { from: 'rankings' } so the facilities page
+ *   renders the correct breadcrumb trail back to rankings.
  */
 export function RankingTableRow({ item, to }) {
   return (

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -832,7 +832,7 @@ export function RankingTableRow({ item, to }) {
           <Link
             to={to}
             state={{ from: 'rankings' }}
-            className="text-paragraph-base font-medium text-blue-600 underline hover:text-blue-800"
+            className="text-paragraph-base font-medium text-blue-700 underline hover:text-blue-800"
           >
             {item.name}
           </Link>

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -815,7 +815,7 @@ NetworkSidePanelList.propTypes = {
  * - rank: number (1-based position)
  * - name: state name string
  */
-export function RankingTableRow({ item }) {
+export function RankingTableRow({ item, to }) {
   return (
     <div
       className="flex items-center justify-between"
@@ -828,9 +828,19 @@ export function RankingTableRow({ item }) {
         >
           {item.rank}
         </span>
-        <span className="text-paragraph-base text-core-black font-medium">
-          {item.name}
-        </span>
+        {to ? (
+          <Link
+            to={to}
+            state={{ from: 'rankings' }}
+            className="text-paragraph-base font-medium text-blue-600 underline hover:text-blue-800"
+          >
+            {item.name}
+          </Link>
+        ) : (
+          <span className="text-paragraph-base text-core-black font-medium">
+            {item.name}
+          </span>
+        )}
       </div>
       <Badge color={item.badgeColor || 'green'} aria-hidden="true">
         #{item.rank}
@@ -845,4 +855,5 @@ RankingTableRow.propTypes = {
     name: PropTypes.string.isRequired,
     badgeColor: PropTypes.string,
   }).isRequired,
+  to: PropTypes.string,
 };

--- a/src/components/ui/molecule/rankingTables.jsx
+++ b/src/components/ui/molecule/rankingTables.jsx
@@ -7,6 +7,31 @@ import SimplePagination from './simplePagination';
 import { RankingTableRow } from './listContainerContent';
 import { RankingTablesSkeleton } from '../atom/skeletons';
 
+/** Maps each ranking metric to the sortBy + sort params for the facilities browse page. */
+const METRIC_TO_SORT = {
+  overall_rank:  'sortBy=overall_rating&sort=desc',
+  rank_financial: 'sortBy=operating_margin&sort=desc',
+  rank_staffing:  'sortBy=staffing_rating&sort=desc',
+  rank_outcomes:  'sortBy=health_inspection_rating&sort=desc',
+};
+
+/** Maps full state/territory names (as used in STATES) to their URL abbreviation. */
+const STATE_NAME_TO_ABBR = {
+  Alabama: 'AL', Alaska: 'AK', Arizona: 'AZ', Arkansas: 'AR',
+  California: 'CA', Colorado: 'CO', Connecticut: 'CT', Delaware: 'DE',
+  Florida: 'FL', Georgia: 'GA', Hawaii: 'HI', Idaho: 'ID',
+  Illinois: 'IL', Indiana: 'IN', Iowa: 'IA', Kansas: 'KS',
+  Kentucky: 'KY', Louisiana: 'LA', Maine: 'ME', Maryland: 'MD',
+  Massachusetts: 'MA', Michigan: 'MI', Minnesota: 'MN', Mississippi: 'MS',
+  Missouri: 'MO', Montana: 'MT', Nebraska: 'NE', Nevada: 'NV',
+  'New Hampshire': 'NH', 'New Jersey': 'NJ', 'New Mexico': 'NM', 'New York': 'NY',
+  'North Carolina': 'NC', 'North Dakota': 'ND', Ohio: 'OH', Oklahoma: 'OK',
+  Oregon: 'OR', Pennsylvania: 'PA', 'Rhode Island': 'RI', 'South Carolina': 'SC',
+  'South Dakota': 'SD', Tennessee: 'TN', Texas: 'TX', Utah: 'UT',
+  Vermont: 'VT', Virginia: 'VA', Washington: 'WA', 'West Virginia': 'WV',
+  Wisconsin: 'WI', Wyoming: 'WY', 'D.C.': 'DC', 'Puerto Rico': 'PR', Guam: 'GU',
+};
+
 const STATES = [
   {
     state: 'Alabama',
@@ -459,17 +484,22 @@ export default function RankingTables({
   const totalItems = sorted.length;
   const pageItems = sorted
     .slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
-    .map((s) => ({
-      id: s.state,
-      rank: s[metric],
-      name: s.state,
-      badgeColor:
-        s[metric] <= 10
-          ? 'green'
-          : s[metric] > STATES.length - 10
-            ? 'red'
-            : 'zinc',
-    }));
+    .map((s) => {
+      const abbr = STATE_NAME_TO_ABBR[s.state];
+      const sortQuery = METRIC_TO_SORT[metric];
+      return {
+        id: s.state,
+        rank: s[metric],
+        name: s.state,
+        to: abbr && sortQuery ? `/facilities?state=${abbr}&${sortQuery}` : undefined,
+        badgeColor:
+          s[metric] <= 10
+            ? 'green'
+            : s[metric] > STATES.length - 10
+              ? 'red'
+              : 'zinc',
+      };
+    });
 
   return (
     <div className="py-2">
@@ -487,7 +517,7 @@ export default function RankingTables({
         >
           {pageItems.map((item) => (
             <li key={item.id} className="py-3">
-              <RankingTableRow item={item} />
+              <RankingTableRow item={item} to={item.to} />
             </li>
           ))}
         </ul>

--- a/src/components/ui/molecule/rankingTables.jsx
+++ b/src/components/ui/molecule/rankingTables.jsx
@@ -451,6 +451,9 @@ RankingTablesToggle.propTypes = {
 /**
  * Paginated state ranking table with Best / Worst toggle.
  *
+ * Each state row links to the facilities browse page pre-filtered by that state
+ * and sorted by the corresponding metric (via METRIC_TO_SORT).
+ *
  * Data is hardcoded in STATES until the backend endpoint is ready.
  * When the API lands, replace STATES with the fetched payload and drive
  * isLoading / error from the query state.

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -9,7 +9,7 @@ import { CheckIcon } from '@heroicons/react/20/solid';
  * Reusable sort/filter control for browse pages.
  *
  * Variants:
- * - `sort`: allows sorting by name (A-Z / Z-A)
+ * - `sort`: sorts by name (A-Z / Z-A) by default; accepts custom sortOptions for field-based sorts
  * - `filter`: allows filtering by state
  *
  * Behavior:

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useId, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/16/solid';
 import PropTypes from 'prop-types';
 import { Heading } from '../atom/heading';
@@ -83,8 +83,8 @@ export default function SelectMenu({
   accessibleLabel,
   sortOptions,
   filterOptions,
+  value,
 }) {
-  const [selected, setSelected] = useState(null); // Stores the current selection for desktop and mobile UIs.
   const [isMobileSortOpen, setIsMobileSortOpen] = useState(false);
   const headingId = useId();
   const mobileTriggerRef = useRef(null);
@@ -94,6 +94,18 @@ export default function SelectMenu({
     variant === 'sort' && sortOptions ? sortOptions :
     variant === 'filter' && filterOptions ? filterOptions :
     OPTIONS[variant] || [];
+
+  // Derive selected option from the value prop (set externally via URL params).
+  // Falls back to null when value is empty/undefined so the placeholder shows.
+  const selectedFromValue = value ? options.find((opt) => opt.value === value) ?? null : null;
+  const [selected, setSelected] = useState(selectedFromValue);
+
+  // Sync whenever the value prop changes (e.g. navigating in from the rankings page).
+  useEffect(() => {
+    setSelected(value ? options.find((opt) => opt.value === value) ?? null : null);
+  // options is a stable module-level or component-prop constant — safe to omit from deps.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   // Applies the selected sort/filter option, or clears back to the default state.
   function handleSelect(option) {
@@ -259,4 +271,6 @@ SelectMenu.propTypes = {
   accessibleLabel: PropTypes.string,
   sortOptions: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })),
   filterOptions: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })),
+  /** The currently active option value (from URL params). Keeps the control in sync on load/navigation. */
+  value: PropTypes.string,
 };

--- a/src/components/ui/organism/browseListView.jsx
+++ b/src/components/ui/organism/browseListView.jsx
@@ -33,6 +33,8 @@ export default function BrowseListView({
   filterAccessibleLabel,
   onFilterChange,
   onSuggestionPick,
+  sortValue,
+  stateValue,
 }) {
   const searchHeadingId = useId();
   const resultsHeadingId = useId();
@@ -69,6 +71,7 @@ export default function BrowseListView({
                 onSortChange={onSortChange}
                 accessibleLabel="Sort results"
                 sortOptions={sortOptions}
+                value={sortValue}
               />
               {/* onFilterChange replaces onStateChange when provided (rankings context only) */}
               <SelectMenu
@@ -76,6 +79,7 @@ export default function BrowseListView({
                 onStateChange={onFilterChange ?? onStateChange}
                 accessibleLabel={filterAccessibleLabel ?? 'Filter by state'}
                 filterOptions={filterOptions}
+                value={stateValue}
               />
             </div>
           </div>
@@ -123,4 +127,6 @@ BrowseListView.propTypes = {
   filterAccessibleLabel: PropTypes.string,
   onFilterChange: PropTypes.func,
   onSuggestionPick: PropTypes.func,
+  sortValue: PropTypes.string,
+  stateValue: PropTypes.string,
 };

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -106,7 +106,6 @@ export default function BrowsePage({
         return res.json();
       })
       .then((resData) => {
-        console.log('[BrowsePage] first facility item:', resData.data?.[0]);
         setData(resData.data);
         setPageCount(resData.pageCount);
       })
@@ -122,7 +121,9 @@ export default function BrowsePage({
       return;
     }
 
-    fetch(`${suggestionsEndpoint ?? `${apiEndpoint}/suggestions`}?search=${search}`)
+    fetch(
+      `${suggestionsEndpoint ?? `${apiEndpoint}/suggestions`}?search=${search}`,
+    )
       .then((res) => res.json())
       .then((resData) => {
         setSuggestions(resData);
@@ -157,6 +158,12 @@ export default function BrowsePage({
         onSearchChange={(val) => updateParam('search', val)}
         sortValue={currentSortValue}
         stateValue={state}
+        // Sort option values follow a "field:direction" encoding convention defined in
+        // FACILITY_SORT_OPTIONS (Facilities.jsx). Field-based sorts use compound values
+        // like "overall_rating:desc", which are split here into separate `sortBy` and
+        // `sort` URL params for the API. Plain "asc"/"desc" values indicate a name sort
+        // and pass through as `sort` only. Any new sort options added to a page that
+        // uses this handler must follow the same convention.
         onSortChange={(val) => {
           setSearchParams((prev) => {
             const params = new URLSearchParams(prev);

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -63,6 +63,7 @@ export default function BrowsePage({
   const page = parseInt(searchParams.get('page')) || 1;
   const search = searchParams.get('search') || '';
   const sort = searchParams.get('sort') || defaultSort;
+  const sortBy = searchParams.get('sortBy') || '';
   const state = searchParams.get('state') || '';
   const chain = searchParams.get('chain') || '';
   // // --- UI State ---
@@ -90,6 +91,8 @@ export default function BrowsePage({
     //  Only add search if it's not empty
     if (search.trim() !== '') params.set('search', search);
     if (chain.trim() !== '') params.set('chain', chain);
+    // sortBy is only set when a field-based sort option is selected (e.g. overall_rating)
+    if (sortBy) params.set('sortBy', sortBy);
 
     fetch(`${apiEndpoint}?${params}`)
       .then((res) => {
@@ -102,7 +105,7 @@ export default function BrowsePage({
       })
       .catch(setError)
       .finally(() => setLoading(false));
-  }, [page, search, sort, state, chain, apiEndpoint]);
+  }, [page, search, sort, sortBy, state, chain, apiEndpoint]);
 
   //Fetch suggestions when user types in the search box
   useEffect(() => {
@@ -145,7 +148,27 @@ export default function BrowsePage({
         onPageChange={(newPage) => updateParam('page', newPage)}
         search={search}
         onSearchChange={(val) => updateParam('search', val)}
-        onSortChange={(val) => val && updateParam('sort', val)}
+        onSortChange={(val) => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.set('page', 1);
+            if (!val) {
+              // Clear button: reset both sort params to defaults
+              params.delete('sort');
+              params.delete('sortBy');
+            } else if (val.includes(':')) {
+              // Compound value like "overall_rating:desc" — split into field + direction
+              const [field, dir] = val.split(':');
+              params.set('sortBy', field);
+              params.set('sort', dir);
+            } else {
+              // Plain direction value ("asc"/"desc") — name sort, clear sortBy
+              params.set('sort', val);
+              params.delete('sortBy');
+            }
+            return params;
+          });
+        }}
         onStateChange={(val) => updateParam('state', val)}
         suggestions={suggestions}
         hasFetchedSuggestions={hasFetchedSuggestions}

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -66,6 +66,12 @@ export default function BrowsePage({
   const sortBy = searchParams.get('sortBy') || '';
   const state = searchParams.get('state') || '';
   const chain = searchParams.get('chain') || '';
+
+  // The compound value the sort SelectMenu should reflect (e.g. "overall_rating:desc" or "asc").
+  // Used to keep the control in sync when URL params arrive via navigation (e.g. from rankings).
+  const currentSortValue = sortBy
+    ? `${sortBy}:${searchParams.get('sort') || defaultSort}`
+    : searchParams.get('sort') || '';
   // // --- UI State ---
   const [hasFetchedSuggestions, setHasFetchedSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState([]);
@@ -149,6 +155,8 @@ export default function BrowsePage({
         onPageChange={(newPage) => updateParam('page', newPage)}
         search={search}
         onSearchChange={(val) => updateParam('search', val)}
+        sortValue={currentSortValue}
+        stateValue={state}
         onSortChange={(val) => {
           setSearchParams((prev) => {
             const params = new URLSearchParams(prev);

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -100,6 +100,7 @@ export default function BrowsePage({
         return res.json();
       })
       .then((resData) => {
+        console.log('[BrowsePage] first facility item:', resData.data?.[0]);
         setData(resData.data);
         setPageCount(resData.pageCount);
       })

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -40,10 +40,14 @@ const API_BASE_URL =
 const FACILITY_SORT_OPTIONS = [
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
-  { label: 'Overall Rating', value: 'overall_rating:desc' },
-  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
-  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
-  { label: 'Operating Margin', value: 'operating_margin:desc' },
+  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
+  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
+  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
+  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
+  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
+  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
+  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
+  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
 ];
 
 function Facilities() {

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -5,7 +5,10 @@ import ListContainer, {
 import { BrowseNursingHomes } from '../components/ui/molecule/listContainerContent';
 import BrowsePage from '../components/ui/organism/browsePage';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
-import { facilityListPages, rankingsFacilityListPages } from '../lib/breadcrumbPages';
+import {
+  facilityListPages,
+  rankingsFacilityListPages,
+} from '../lib/breadcrumbPages';
 import { useSearchParams, useLocation } from 'react-router-dom';
 import { toTitleCase } from '../lib/toTitleCase';
 
@@ -20,6 +23,7 @@ import { toTitleCase } from '../lib/toTitleCase';
  * - title: Page title
  * - searchPlaceholder: Input placeholder text
  * - type: Entity type for routing (facilities)
+ * - sortOptions: Facilities-specific sort options (see FACILITY_SORT_OPTIONS)
  * - renderList: Function rendering the list of facilities
  */
 
@@ -36,21 +40,18 @@ const API_BASE_URL =
 const FACILITY_SORT_OPTIONS = [
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
-  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
-  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
-  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
-  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
-  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
-  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
-  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
-  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
+  { label: 'Overall Rating', value: 'overall_rating:desc' },
+  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
+  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
+  { label: 'Operating Margin', value: 'operating_margin:desc' },
 ];
 
 function Facilities() {
   const [searchParams] = useSearchParams();
   const { state } = useLocation();
   const chain = searchParams.get('chain');
-  const breadcrumb = state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
+  const breadcrumb =
+    state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
   return (
     <>
       <Breadcrumb pages={breadcrumb} />
@@ -63,16 +64,26 @@ function Facilities() {
         renderList={(items) => (
           <>
             {chain && (
-              <div className="mb-4 mt-2 text-center">
-                <span className="inline-block rounded bg-blue-50 px-4 py-2 text-base font-semibold text-blue-700 border border-blue-100">
-                  Showing facilities for operator: {toTitleCase(chain.replace(/-/g, ' '))}
+              <div className="mt-2 mb-4 text-center">
+                <span className="inline-block rounded border border-blue-100 bg-blue-50 px-4 py-2 text-base font-semibold text-blue-700">
+                  Showing facilities for operator:{' '}
+                  {toTitleCase(chain.replace(/-/g, ' '))}
                 </span>
               </div>
             )}
             <ListContainer
               items={items}
               LayoutSelector={ListContainerSeparate}
-              ListContent={state?.from === 'rankings' ? (props) => <BrowseNursingHomes {...props} linkState={{ from: 'rankings' }} /> : BrowseNursingHomes}
+              ListContent={
+                state?.from === 'rankings'
+                  ? (props) => (
+                      <BrowseNursingHomes
+                        {...props}
+                        linkState={{ from: 'rankings' }}
+                      />
+                    )
+                  : BrowseNursingHomes
+              }
             />
           </>
         )}

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -34,12 +34,16 @@ const API_BASE_URL =
  * Plain "asc"/"desc" values fall back to the default name-based sort.
  */
 const FACILITY_SORT_OPTIONS = [
-  { label: 'Overall Rating', value: 'overall_rating:desc' },
-  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
-  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
-  { label: 'Operating Margin', value: 'operating_margin:desc' },
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
+  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
+  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
+  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
+  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
+  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
+  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
+  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
+  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
 ];
 
 function Facilities() {

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -27,6 +27,21 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 
+/**
+ * Sort options for the facilities browse page.
+ * Rating fields use a compound "field:direction" value so browsePage can split
+ * them into separate `sortBy` and `sort` URL params for the API.
+ * Plain "asc"/"desc" values fall back to the default name-based sort.
+ */
+const FACILITY_SORT_OPTIONS = [
+  { label: 'Overall Rating', value: 'overall_rating:desc' },
+  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
+  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
+  { label: 'Operating Margin', value: 'operating_margin:desc' },
+  { label: 'Name (A–Z)', value: 'asc' },
+  { label: 'Name (Z–A)', value: 'desc' },
+];
+
 function Facilities() {
   const [searchParams] = useSearchParams();
   const { state } = useLocation();
@@ -40,6 +55,7 @@ function Facilities() {
         title="Nursing Homes"
         searchPlaceholder="Nursing home name..."
         type="facilities"
+        sortOptions={FACILITY_SORT_OPTIONS}
         renderList={(items) => (
           <>
             {chain && (


### PR DESCRIPTION
## Implement sort fields for facilities browse

Adds field-based sorting to the facilities browse page and connects 
the state rankings tables to it.

### Changes
- **Facilities sort options** — new sort options for Overall Rating, 
  Staffing Rating, Health Inspection, and Financial (high→low and 
  low→high for each), alongside the existing Name A–Z / Z–A
- **API wiring** — `browsePage` now handles a compound `field:direction` 
  sort encoding, splitting it into the `sortBy` + `sort` params the 
  backend expects
- **Sort/filter UI sync** — `SelectMenu` now reflects pre-applied URL 
  params on load, so navigating in from another page shows the correct 
  selections in the dropdowns
- **Ranking table links** — state rows in the rankings tables are now 
  links that land on the facilities page pre-filtered by that state and 
  sorted by the relevant metric

### Coming next
A follow-up PR (`facility-rating-card`) will add a new card component 
that surfaces the rating data when a field-based sort is active.
