### PR TITLE
Facilty rating card  **REQUIRES #59**  2/2

### DIFF
--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -394,6 +394,127 @@ BrowseNursingHomes.propTypes = {
   linkState: PropTypes.object,
 };
 
+/**
+ * Facility browse card variant that surfaces rating metrics in the bottom row.
+ * Used on the facilities browse page when a field-based sort is active
+ * (overall rating, staffing, health inspection, or financial).
+ *
+ * The top section (name, address, View Profile) is identical to BrowseNursingHomes.
+ * The bottom row replaces ownership info with four stat blocks:
+ * Overall, Health Insp., Staffing, and Financial.
+ *
+ * Props:
+ * - item: facility data object
+ * - linkState: optional router state passed through to the facility profile link (e.g. { from: 'rankings' })
+ * - activeMetric: which stat block to visually highlight — matches the active sortBy field
+ *   ('overall_rating' | 'health_inspection_rating' | 'staffing_rating' | 'operating_margin')
+ */
+export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
+  if (!item) {
+    return (
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="md:col-span-3">
+          <p className="text-paragraph-base text-red-600">
+            Error: Invalid facility data
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const facilityHref = `/facilities/${item.slug}`;
+  const facilityName = toTitleCase(item.provider_name || 'Unknown Facility');
+
+  // TODO: replace placeholder values with real field names once confirmed from API response
+  const stats = [
+    { key: 'overall_rating', label: 'Overall', value: item.overall_rating ?? '—', type: 'stars' },
+    { key: 'health_inspection_rating', label: 'Health insp.', value: item.health_inspection_rating ?? '—', type: 'stars' },
+    { key: 'staffing_rating', label: 'Staffing', value: item.staffing_rating ?? '—', type: 'stars' },
+    { key: 'operating_margin', label: 'Financial', value: item.operating_margin ?? '—', type: 'financial' },
+  ];
+
+  return (
+    <Link
+      to={facilityHref}
+      state={linkState}
+      className="focus-ring-light block rounded-lg"
+      aria-label={`View profile for ${facilityName}`}
+    >
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {/* Name + Address */}
+        <div className="md:col-span-2">
+          <span
+            className="text-heading-xs font-bold text-blue-600 underline"
+            style={{
+              textDecorationThickness: '2px',
+              textUnderlineOffset: '2px',
+            }}
+          >
+            {facilityName}
+          </span>
+          <p className="text-paragraph-base text-content-secondary hidden py-2 md:block md:py-0 md:pt-2">
+            {item.street_address && item.city && item.state
+              ? `${toTitleCase(item.street_address || '')}, ${toTitleCase(item.city || '')}, ${item.state || ''}`
+              : 'Address not available'}
+          </p>
+        </div>
+
+        {/* Button — Top right on desktop, bottom on mobile */}
+        <div className="order-3 md:order-none md:flex md:items-center md:justify-end">
+          <span className="text-label-base border-border-primary inline-block w-full rounded-lg border px-4 py-2 text-center font-extrabold md:w-auto">
+            View Profile
+          </span>
+        </div>
+
+        {/* Divider */}
+        <Divider className="order-2 md:order-none md:col-span-3" />
+
+        {/* Bottom Row — rating stats */}
+        <div className="order-2 md:order-none md:col-span-3 flex flex-row gap-2">
+          {stats.map((stat) => {
+            const isActive = stat.key === activeMetric;
+            return (
+              <div
+                key={stat.key}
+                className={clsx(
+                  'flex flex-col gap-1 rounded-md px-3 py-2',
+                  isActive && 'bg-gray-100',
+                )}
+              >
+                <p className="text-paragraph-sm text-content-secondary">{stat.label}</p>
+                {stat.type === 'stars' ? (
+                  <div className="flex items-center gap-1">
+                    <StarRating rating={typeof stat.value === 'number' ? stat.value : 0} />
+                    <span className="text-paragraph-base font-bold">{stat.value}</span>
+                  </div>
+                ) : (
+                  <div className="flex flex-col">
+                    <span className="text-paragraph-base font-bold">
+                      {typeof stat.value === 'number' ? `${(stat.value * 100).toFixed(1)}%` : stat.value}
+                    </span>
+                    <span className="text-paragraph-sm text-content-secondary">op. margin</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+BrowseNursingHomesRatings.propTypes = {
+  item: PropTypes.object.isRequired,
+  linkState: PropTypes.object,
+  activeMetric: PropTypes.oneOf([
+    'overall_rating',
+    'health_inspection_rating',
+    'staffing_rating',
+    'operating_margin',
+  ]),
+};
+
 export function BrowseChains({ item }) {
   return (
     <Link

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -814,6 +814,12 @@ NetworkSidePanelList.propTypes = {
  * Expected item shape:
  * - rank: number (1-based position)
  * - name: state name string
+ *
+ * Props:
+ * - to: optional URL string; when provided, renders the state name as a link
+ *   to the facilities browse page pre-filtered by state and sort.
+ *   The link passes router state { from: 'rankings' } so the facilities page
+ *   renders the correct breadcrumb trail back to rankings.
  */
 export function RankingTableRow({ item, to }) {
   return (

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -402,11 +402,19 @@ BrowseNursingHomes.propTypes = {
  *
  * The top section (name, address, View Profile) is identical to BrowseNursingHomes.
  * The bottom row replaces ownership info with four stat blocks:
- * Overall, Health Insp., Staffing, and Financial.
+ * - Overall, Health Insp., Staffing: star rating display
+ * - Financial: operating margin percentage + comparison badge (Above/Below avg.)
+ *   sourced from cmpr_operating_margin. Higher is better, so above avg. = green,
+ *   below avg. = red. The financial block always carries a border to visually
+ *   group its denser two-row layout, even when it is not the active sort metric.
+ *
+ * The active stat block (matching activeMetric) receives a highlighted background
+ * in addition to its border.
  *
  * Props:
  * - item: facility data object
- * - linkState: optional router state passed through to the facility profile link (e.g. { from: 'rankings' })
+ * - linkState: optional router state passed through to the facility profile link
+ *   (e.g. { from: 'rankings' } to preserve the breadcrumb trail)
  * - activeMetric: which stat block to visually highlight — matches the active sortBy field
  *   ('overall_rating' | 'health_inspection_rating' | 'staffing_rating' | 'operating_margin')
  */
@@ -502,6 +510,8 @@ export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
                   'flex flex-1 gap-1 rounded-md px-3 py-2 md:flex-col',
                   isActive
                     ? 'bg-background-secondary border-border-primary border'
+                    // Financial always gets a border (inactive) to visually group
+                    // its two-row layout; active state upgrades it with a background.
                     : stat.type === 'financial' &&
                         'border-border-primary border',
                 )}

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -9,6 +9,7 @@ import { toTitleCase } from '../../../lib/toTitleCase';
 import {
   badgeConfig,
   getBadgeColorAboveBelow,
+  getCmprColor,
 } from '../../../lib/getBadgeColor';
 import { ownerRoleMap } from '../../../lib/ownerRoleHelper';
 import LayoutCard from '../atom/layout-card';
@@ -448,10 +449,11 @@ export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
       key: 'operating_margin',
       label: 'Financial',
       value: item.operating_margin ?? '—',
+      comparison: item.cmpr_operating_margin ?? null,
+      comparisonColor: getCmprColor(item.cmpr_operating_margin, true),
       type: 'financial',
     },
   ];
-
   return (
     <Link
       to={facilityHref}
@@ -498,32 +500,55 @@ export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
                 key={stat.key}
                 className={clsx(
                   'flex flex-1 gap-1 rounded-md px-3 py-2 md:flex-col',
-                  isActive &&
-                    'bg-background-secondary border-border-primary border',
+                  isActive
+                    ? 'bg-background-secondary border-border-primary border'
+                    : stat.type === 'financial' &&
+                        'border-border-primary border',
                 )}
               >
-                <p className="text-paragraph-sm text-content-secondary">
-                  {stat.label}
-                </p>
-                {stat.type === 'stars' ? (
-                  <StarRating
-                    title=""
-                    rating={typeof stat.value === 'number' ? stat.value : 0}
-                    size="h-4 w-4"
-                    ratingSize="sm"
-                  />
-                ) : (
-                  <div className="flex flex-col">
-                    <span className="text-paragraph-base font-bold">
-                      {typeof stat.value === 'number'
-                        ? `${stat.value.toFixed(1)}%`
-                        : stat.value}
-                    </span>
-                    <span className="text-paragraph-sm text-content-secondary">
-                      op. margin
-                    </span>
+                {stat.type === 'financial' ? (
+                  // Financial block: row1 = label + badge, row2 = op. margin + value
+                  // flex-col + w-full ensures two-row layout even when parent is flex-row (mobile)
+                  <div className="flex w-full flex-col">
+                    <div className="flex items-center justify-between">
+                      <p className="text-paragraph-sm text-content-secondary">
+                        {stat.label}
+                      </p>
+                      {stat.comparison && (
+                        <Badge color={stat.comparisonColor || 'zinc'}>
+                          {stat.comparison.toLowerCase().includes('above')
+                            ? 'Above avg.'
+                            : stat.comparison.toLowerCase().includes('below')
+                              ? 'Below avg.'
+                              : 'Avg.'}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-paragraph-sm text-content-tertiary">
+                        op. margin
+                      </span>
+                      <span className="text-paragraph-base font-bold">
+                        {typeof stat.value === 'number'
+                          ? `${stat.value.toFixed(1)}%`
+                          : stat.value}
+                      </span>
+                    </div>
                   </div>
-                )}
+                ) : stat.type === 'stars' ? (
+                  // Mobile: label left, stars right. Desktop: label top, stars below.
+                  <div className="flex w-full items-center justify-between md:flex-col md:items-start">
+                    <p className="text-paragraph-sm text-content-secondary">
+                      {stat.label}
+                    </p>
+                    <StarRating
+                      title=""
+                      rating={typeof stat.value === 'number' ? stat.value : 0}
+                      size="h-4 w-4"
+                      ratingSize="sm"
+                    />
+                  </div>
+                ) : null}
               </div>
             );
           })}
@@ -670,6 +695,7 @@ BrowseOwners.propTypes = {
       }),
     ),
   }).isRequired,
+  linkState: PropTypes.object,
 };
 
 /**

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -832,7 +832,7 @@ export function RankingTableRow({ item, to }) {
           <Link
             to={to}
             state={{ from: 'rankings' }}
-            className="text-paragraph-base font-medium text-blue-600 underline hover:text-blue-800"
+            className="text-paragraph-base font-medium text-blue-700 underline hover:text-blue-800"
           >
             {item.name}
           </Link>

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -815,7 +815,7 @@ NetworkSidePanelList.propTypes = {
  * - rank: number (1-based position)
  * - name: state name string
  */
-export function RankingTableRow({ item }) {
+export function RankingTableRow({ item, to }) {
   return (
     <div
       className="flex items-center justify-between"
@@ -828,9 +828,19 @@ export function RankingTableRow({ item }) {
         >
           {item.rank}
         </span>
-        <span className="text-paragraph-base text-core-black font-medium">
-          {item.name}
-        </span>
+        {to ? (
+          <Link
+            to={to}
+            state={{ from: 'rankings' }}
+            className="text-paragraph-base font-medium text-blue-600 underline hover:text-blue-800"
+          >
+            {item.name}
+          </Link>
+        ) : (
+          <span className="text-paragraph-base text-core-black font-medium">
+            {item.name}
+          </span>
+        )}
       </div>
       <Badge color={item.badgeColor || 'green'} aria-hidden="true">
         #{item.rank}
@@ -845,4 +855,5 @@ RankingTableRow.propTypes = {
     name: PropTypes.string.isRequired,
     badgeColor: PropTypes.string,
   }).isRequired,
+  to: PropTypes.string,
 };

--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -425,12 +425,31 @@ export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
   const facilityHref = `/facilities/${item.slug}`;
   const facilityName = toTitleCase(item.provider_name || 'Unknown Facility');
 
-  // TODO: replace placeholder values with real field names once confirmed from API response
   const stats = [
-    { key: 'overall_rating', label: 'Overall', value: item.overall_rating ?? '—', type: 'stars' },
-    { key: 'health_inspection_rating', label: 'Health insp.', value: item.health_inspection_rating ?? '—', type: 'stars' },
-    { key: 'staffing_rating', label: 'Staffing', value: item.staffing_rating ?? '—', type: 'stars' },
-    { key: 'operating_margin', label: 'Financial', value: item.operating_margin ?? '—', type: 'financial' },
+    {
+      key: 'overall_rating',
+      label: 'Overall',
+      value: item.overall_rating ?? '—',
+      type: 'stars',
+    },
+    {
+      key: 'health_inspection_rating',
+      label: 'Health insp.',
+      value: item.health_inspection_rating ?? '—',
+      type: 'stars',
+    },
+    {
+      key: 'staffing_rating',
+      label: 'Staffing',
+      value: item.staffing_rating ?? '—',
+      type: 'stars',
+    },
+    {
+      key: 'operating_margin',
+      label: 'Financial',
+      value: item.operating_margin ?? '—',
+      type: 'financial',
+    },
   ];
 
   return (
@@ -469,30 +488,40 @@ export function BrowseNursingHomesRatings({ item, linkState, activeMetric }) {
         {/* Divider */}
         <Divider className="order-2 md:order-none md:col-span-3" />
 
-        {/* Bottom Row — rating stats */}
-        <div className="order-2 md:order-none md:col-span-3 flex flex-row gap-2">
+        {/* Bottom Row — rating stats. cursor-default prevents the pointer cursor
+            on hover, signalling these blocks are informational, not interactive. */}
+        <div className="order-2 flex cursor-default flex-col gap-2 md:order-none md:col-span-3 md:flex-row">
           {stats.map((stat) => {
             const isActive = stat.key === activeMetric;
             return (
               <div
                 key={stat.key}
                 className={clsx(
-                  'flex flex-col gap-1 rounded-md px-3 py-2',
-                  isActive && 'bg-gray-100',
+                  'flex flex-1 gap-1 rounded-md px-3 py-2 md:flex-col',
+                  isActive &&
+                    'bg-background-secondary border-border-primary border',
                 )}
               >
-                <p className="text-paragraph-sm text-content-secondary">{stat.label}</p>
+                <p className="text-paragraph-sm text-content-secondary">
+                  {stat.label}
+                </p>
                 {stat.type === 'stars' ? (
-                  <div className="flex items-center gap-1">
-                    <StarRating rating={typeof stat.value === 'number' ? stat.value : 0} />
-                    <span className="text-paragraph-base font-bold">{stat.value}</span>
-                  </div>
+                  <StarRating
+                    title=""
+                    rating={typeof stat.value === 'number' ? stat.value : 0}
+                    size="h-4 w-4"
+                    ratingSize="sm"
+                  />
                 ) : (
                   <div className="flex flex-col">
                     <span className="text-paragraph-base font-bold">
-                      {typeof stat.value === 'number' ? `${(stat.value * 100).toFixed(1)}%` : stat.value}
+                      {typeof stat.value === 'number'
+                        ? `${stat.value.toFixed(1)}%`
+                        : stat.value}
                     </span>
-                    <span className="text-paragraph-sm text-content-secondary">op. margin</span>
+                    <span className="text-paragraph-sm text-content-secondary">
+                      op. margin
+                    </span>
                   </div>
                 )}
               </div>

--- a/src/components/ui/molecule/rankingTables.jsx
+++ b/src/components/ui/molecule/rankingTables.jsx
@@ -7,6 +7,31 @@ import SimplePagination from './simplePagination';
 import { RankingTableRow } from './listContainerContent';
 import { RankingTablesSkeleton } from '../atom/skeletons';
 
+/** Maps each ranking metric to the sortBy + sort params for the facilities browse page. */
+const METRIC_TO_SORT = {
+  overall_rank:  'sortBy=overall_rating&sort=desc',
+  rank_financial: 'sortBy=operating_margin&sort=desc',
+  rank_staffing:  'sortBy=staffing_rating&sort=desc',
+  rank_outcomes:  'sortBy=health_inspection_rating&sort=desc',
+};
+
+/** Maps full state/territory names (as used in STATES) to their URL abbreviation. */
+const STATE_NAME_TO_ABBR = {
+  Alabama: 'AL', Alaska: 'AK', Arizona: 'AZ', Arkansas: 'AR',
+  California: 'CA', Colorado: 'CO', Connecticut: 'CT', Delaware: 'DE',
+  Florida: 'FL', Georgia: 'GA', Hawaii: 'HI', Idaho: 'ID',
+  Illinois: 'IL', Indiana: 'IN', Iowa: 'IA', Kansas: 'KS',
+  Kentucky: 'KY', Louisiana: 'LA', Maine: 'ME', Maryland: 'MD',
+  Massachusetts: 'MA', Michigan: 'MI', Minnesota: 'MN', Mississippi: 'MS',
+  Missouri: 'MO', Montana: 'MT', Nebraska: 'NE', Nevada: 'NV',
+  'New Hampshire': 'NH', 'New Jersey': 'NJ', 'New Mexico': 'NM', 'New York': 'NY',
+  'North Carolina': 'NC', 'North Dakota': 'ND', Ohio: 'OH', Oklahoma: 'OK',
+  Oregon: 'OR', Pennsylvania: 'PA', 'Rhode Island': 'RI', 'South Carolina': 'SC',
+  'South Dakota': 'SD', Tennessee: 'TN', Texas: 'TX', Utah: 'UT',
+  Vermont: 'VT', Virginia: 'VA', Washington: 'WA', 'West Virginia': 'WV',
+  Wisconsin: 'WI', Wyoming: 'WY', 'D.C.': 'DC', 'Puerto Rico': 'PR', Guam: 'GU',
+};
+
 const STATES = [
   {
     state: 'Alabama',
@@ -459,17 +484,22 @@ export default function RankingTables({
   const totalItems = sorted.length;
   const pageItems = sorted
     .slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
-    .map((s) => ({
-      id: s.state,
-      rank: s[metric],
-      name: s.state,
-      badgeColor:
-        s[metric] <= 10
-          ? 'green'
-          : s[metric] > STATES.length - 10
-            ? 'red'
-            : 'zinc',
-    }));
+    .map((s) => {
+      const abbr = STATE_NAME_TO_ABBR[s.state];
+      const sortQuery = METRIC_TO_SORT[metric];
+      return {
+        id: s.state,
+        rank: s[metric],
+        name: s.state,
+        to: abbr && sortQuery ? `/facilities?state=${abbr}&${sortQuery}` : undefined,
+        badgeColor:
+          s[metric] <= 10
+            ? 'green'
+            : s[metric] > STATES.length - 10
+              ? 'red'
+              : 'zinc',
+      };
+    });
 
   return (
     <div className="py-2">
@@ -487,7 +517,7 @@ export default function RankingTables({
         >
           {pageItems.map((item) => (
             <li key={item.id} className="py-3">
-              <RankingTableRow item={item} />
+              <RankingTableRow item={item} to={item.to} />
             </li>
           ))}
         </ul>

--- a/src/components/ui/molecule/rankingTables.jsx
+++ b/src/components/ui/molecule/rankingTables.jsx
@@ -451,6 +451,9 @@ RankingTablesToggle.propTypes = {
 /**
  * Paginated state ranking table with Best / Worst toggle.
  *
+ * Each state row links to the facilities browse page pre-filtered by that state
+ * and sorted by the corresponding metric (via METRIC_TO_SORT).
+ *
  * Data is hardcoded in STATES until the backend endpoint is ready.
  * When the API lands, replace STATES with the fetched payload and drive
  * isLoading / error from the query state.

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -9,7 +9,7 @@ import { CheckIcon } from '@heroicons/react/20/solid';
  * Reusable sort/filter control for browse pages.
  *
  * Variants:
- * - `sort`: allows sorting by name (A-Z / Z-A)
+ * - `sort`: sorts by name (A-Z / Z-A) by default; accepts custom sortOptions for field-based sorts
  * - `filter`: allows filtering by state
  *
  * Behavior:

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useId, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/16/solid';
 import PropTypes from 'prop-types';
 import { Heading } from '../atom/heading';
@@ -83,8 +83,8 @@ export default function SelectMenu({
   accessibleLabel,
   sortOptions,
   filterOptions,
+  value,
 }) {
-  const [selected, setSelected] = useState(null); // Stores the current selection for desktop and mobile UIs.
   const [isMobileSortOpen, setIsMobileSortOpen] = useState(false);
   const headingId = useId();
   const mobileTriggerRef = useRef(null);
@@ -94,6 +94,18 @@ export default function SelectMenu({
     variant === 'sort' && sortOptions ? sortOptions :
     variant === 'filter' && filterOptions ? filterOptions :
     OPTIONS[variant] || [];
+
+  // Derive selected option from the value prop (set externally via URL params).
+  // Falls back to null when value is empty/undefined so the placeholder shows.
+  const selectedFromValue = value ? options.find((opt) => opt.value === value) ?? null : null;
+  const [selected, setSelected] = useState(selectedFromValue);
+
+  // Sync whenever the value prop changes (e.g. navigating in from the rankings page).
+  useEffect(() => {
+    setSelected(value ? options.find((opt) => opt.value === value) ?? null : null);
+  // options is a stable module-level or component-prop constant — safe to omit from deps.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   // Applies the selected sort/filter option, or clears back to the default state.
   function handleSelect(option) {
@@ -259,4 +271,6 @@ SelectMenu.propTypes = {
   accessibleLabel: PropTypes.string,
   sortOptions: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })),
   filterOptions: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })),
+  /** The currently active option value (from URL params). Keeps the control in sync on load/navigation. */
+  value: PropTypes.string,
 };

--- a/src/components/ui/organism/browseListView.jsx
+++ b/src/components/ui/organism/browseListView.jsx
@@ -33,6 +33,8 @@ export default function BrowseListView({
   filterAccessibleLabel,
   onFilterChange,
   onSuggestionPick,
+  sortValue,
+  stateValue,
 }) {
   const searchHeadingId = useId();
   const resultsHeadingId = useId();
@@ -69,6 +71,7 @@ export default function BrowseListView({
                 onSortChange={onSortChange}
                 accessibleLabel="Sort results"
                 sortOptions={sortOptions}
+                value={sortValue}
               />
               {/* onFilterChange replaces onStateChange when provided (rankings context only) */}
               <SelectMenu
@@ -76,6 +79,7 @@ export default function BrowseListView({
                 onStateChange={onFilterChange ?? onStateChange}
                 accessibleLabel={filterAccessibleLabel ?? 'Filter by state'}
                 filterOptions={filterOptions}
+                value={stateValue}
               />
             </div>
           </div>
@@ -123,4 +127,6 @@ BrowseListView.propTypes = {
   filterAccessibleLabel: PropTypes.string,
   onFilterChange: PropTypes.func,
   onSuggestionPick: PropTypes.func,
+  sortValue: PropTypes.string,
+  stateValue: PropTypes.string,
 };

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -106,7 +106,6 @@ export default function BrowsePage({
         return res.json();
       })
       .then((resData) => {
-        console.log('[BrowsePage] first facility item:', resData.data?.[0]);
         setData(resData.data);
         setPageCount(resData.pageCount);
       })
@@ -122,7 +121,9 @@ export default function BrowsePage({
       return;
     }
 
-    fetch(`${suggestionsEndpoint ?? `${apiEndpoint}/suggestions`}?search=${search}`)
+    fetch(
+      `${suggestionsEndpoint ?? `${apiEndpoint}/suggestions`}?search=${search}`,
+    )
       .then((res) => res.json())
       .then((resData) => {
         setSuggestions(resData);
@@ -157,6 +158,12 @@ export default function BrowsePage({
         onSearchChange={(val) => updateParam('search', val)}
         sortValue={currentSortValue}
         stateValue={state}
+        // Sort option values follow a "field:direction" encoding convention defined in
+        // FACILITY_SORT_OPTIONS (Facilities.jsx). Field-based sorts use compound values
+        // like "overall_rating:desc", which are split here into separate `sortBy` and
+        // `sort` URL params for the API. Plain "asc"/"desc" values indicate a name sort
+        // and pass through as `sort` only. Any new sort options added to a page that
+        // uses this handler must follow the same convention.
         onSortChange={(val) => {
           setSearchParams((prev) => {
             const params = new URLSearchParams(prev);

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -63,6 +63,7 @@ export default function BrowsePage({
   const page = parseInt(searchParams.get('page')) || 1;
   const search = searchParams.get('search') || '';
   const sort = searchParams.get('sort') || defaultSort;
+  const sortBy = searchParams.get('sortBy') || '';
   const state = searchParams.get('state') || '';
   const chain = searchParams.get('chain') || '';
   // // --- UI State ---
@@ -90,6 +91,8 @@ export default function BrowsePage({
     //  Only add search if it's not empty
     if (search.trim() !== '') params.set('search', search);
     if (chain.trim() !== '') params.set('chain', chain);
+    // sortBy is only set when a field-based sort option is selected (e.g. overall_rating)
+    if (sortBy) params.set('sortBy', sortBy);
 
     fetch(`${apiEndpoint}?${params}`)
       .then((res) => {
@@ -102,7 +105,7 @@ export default function BrowsePage({
       })
       .catch(setError)
       .finally(() => setLoading(false));
-  }, [page, search, sort, state, chain, apiEndpoint]);
+  }, [page, search, sort, sortBy, state, chain, apiEndpoint]);
 
   //Fetch suggestions when user types in the search box
   useEffect(() => {
@@ -145,7 +148,27 @@ export default function BrowsePage({
         onPageChange={(newPage) => updateParam('page', newPage)}
         search={search}
         onSearchChange={(val) => updateParam('search', val)}
-        onSortChange={(val) => val && updateParam('sort', val)}
+        onSortChange={(val) => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.set('page', 1);
+            if (!val) {
+              // Clear button: reset both sort params to defaults
+              params.delete('sort');
+              params.delete('sortBy');
+            } else if (val.includes(':')) {
+              // Compound value like "overall_rating:desc" — split into field + direction
+              const [field, dir] = val.split(':');
+              params.set('sortBy', field);
+              params.set('sort', dir);
+            } else {
+              // Plain direction value ("asc"/"desc") — name sort, clear sortBy
+              params.set('sort', val);
+              params.delete('sortBy');
+            }
+            return params;
+          });
+        }}
         onStateChange={(val) => updateParam('state', val)}
         suggestions={suggestions}
         hasFetchedSuggestions={hasFetchedSuggestions}

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -66,6 +66,12 @@ export default function BrowsePage({
   const sortBy = searchParams.get('sortBy') || '';
   const state = searchParams.get('state') || '';
   const chain = searchParams.get('chain') || '';
+
+  // The compound value the sort SelectMenu should reflect (e.g. "overall_rating:desc" or "asc").
+  // Used to keep the control in sync when URL params arrive via navigation (e.g. from rankings).
+  const currentSortValue = sortBy
+    ? `${sortBy}:${searchParams.get('sort') || defaultSort}`
+    : searchParams.get('sort') || '';
   // // --- UI State ---
   const [hasFetchedSuggestions, setHasFetchedSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState([]);
@@ -149,6 +155,8 @@ export default function BrowsePage({
         onPageChange={(newPage) => updateParam('page', newPage)}
         search={search}
         onSearchChange={(val) => updateParam('search', val)}
+        sortValue={currentSortValue}
+        stateValue={state}
         onSortChange={(val) => {
           setSearchParams((prev) => {
             const params = new URLSearchParams(prev);

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -100,6 +100,7 @@ export default function BrowsePage({
         return res.json();
       })
       .then((resData) => {
+        console.log('[BrowsePage] first facility item:', resData.data?.[0]);
         setData(resData.data);
         setPageCount(resData.pageCount);
       })

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -40,10 +40,14 @@ const API_BASE_URL =
 const FACILITY_SORT_OPTIONS = [
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
-  { label: 'Overall Rating', value: 'overall_rating:desc' },
-  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
-  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
-  { label: 'Operating Margin', value: 'operating_margin:desc' },
+  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
+  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
+  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
+  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
+  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
+  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
+  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
+  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
 ];
 
 function Facilities() {

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -5,7 +5,10 @@ import ListContainer, {
 import { BrowseNursingHomes } from '../components/ui/molecule/listContainerContent';
 import BrowsePage from '../components/ui/organism/browsePage';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
-import { facilityListPages, rankingsFacilityListPages } from '../lib/breadcrumbPages';
+import {
+  facilityListPages,
+  rankingsFacilityListPages,
+} from '../lib/breadcrumbPages';
 import { useSearchParams, useLocation } from 'react-router-dom';
 import { toTitleCase } from '../lib/toTitleCase';
 
@@ -20,6 +23,7 @@ import { toTitleCase } from '../lib/toTitleCase';
  * - title: Page title
  * - searchPlaceholder: Input placeholder text
  * - type: Entity type for routing (facilities)
+ * - sortOptions: Facilities-specific sort options (see FACILITY_SORT_OPTIONS)
  * - renderList: Function rendering the list of facilities
  */
 
@@ -36,21 +40,18 @@ const API_BASE_URL =
 const FACILITY_SORT_OPTIONS = [
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
-  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
-  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
-  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
-  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
-  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
-  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
-  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
-  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
+  { label: 'Overall Rating', value: 'overall_rating:desc' },
+  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
+  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
+  { label: 'Operating Margin', value: 'operating_margin:desc' },
 ];
 
 function Facilities() {
   const [searchParams] = useSearchParams();
   const { state } = useLocation();
   const chain = searchParams.get('chain');
-  const breadcrumb = state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
+  const breadcrumb =
+    state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
   return (
     <>
       <Breadcrumb pages={breadcrumb} />
@@ -63,16 +64,26 @@ function Facilities() {
         renderList={(items) => (
           <>
             {chain && (
-              <div className="mb-4 mt-2 text-center">
-                <span className="inline-block rounded bg-blue-50 px-4 py-2 text-base font-semibold text-blue-700 border border-blue-100">
-                  Showing facilities for operator: {toTitleCase(chain.replace(/-/g, ' '))}
+              <div className="mt-2 mb-4 text-center">
+                <span className="inline-block rounded border border-blue-100 bg-blue-50 px-4 py-2 text-base font-semibold text-blue-700">
+                  Showing facilities for operator:{' '}
+                  {toTitleCase(chain.replace(/-/g, ' '))}
                 </span>
               </div>
             )}
             <ListContainer
               items={items}
               LayoutSelector={ListContainerSeparate}
-              ListContent={state?.from === 'rankings' ? (props) => <BrowseNursingHomes {...props} linkState={{ from: 'rankings' }} /> : BrowseNursingHomes}
+              ListContent={
+                state?.from === 'rankings'
+                  ? (props) => (
+                      <BrowseNursingHomes
+                        {...props}
+                        linkState={{ from: 'rankings' }}
+                      />
+                    )
+                  : BrowseNursingHomes
+              }
             />
           </>
         )}

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ListContainer, {
   ListContainerSeparate,
 } from '../components/ui/organism/ListContainer';
-import { BrowseNursingHomes } from '../components/ui/molecule/listContainerContent';
+import { BrowseNursingHomes, BrowseNursingHomesRatings } from '../components/ui/molecule/listContainerContent';
 import BrowsePage from '../components/ui/organism/browsePage';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import {
@@ -54,8 +54,19 @@ function Facilities() {
   const [searchParams] = useSearchParams();
   const { state } = useLocation();
   const chain = searchParams.get('chain');
+  const sortBy = searchParams.get('sortBy') || '';
   const breadcrumb =
     state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
+
+  // Pass linkState through to whichever card is rendered so the breadcrumb trail is correct.
+  const linkState = state?.from === 'rankings' ? { from: 'rankings' } : undefined;
+
+  // When a field-based sort is active, show the ratings card with that metric highlighted.
+  // Otherwise fall back to the standard ownership card.
+  const CardComponent = sortBy
+    ? (props) => <BrowseNursingHomesRatings {...props} activeMetric={sortBy} linkState={linkState} />
+    : (props) => <BrowseNursingHomes {...props} linkState={linkState} />;
+
   return (
     <>
       <Breadcrumb pages={breadcrumb} />
@@ -78,16 +89,7 @@ function Facilities() {
             <ListContainer
               items={items}
               LayoutSelector={ListContainerSeparate}
-              ListContent={
-                state?.from === 'rankings'
-                  ? (props) => (
-                      <BrowseNursingHomes
-                        {...props}
-                        linkState={{ from: 'rankings' }}
-                      />
-                    )
-                  : BrowseNursingHomes
-              }
+              ListContent={CardComponent}
             />
           </>
         )}

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -34,12 +34,16 @@ const API_BASE_URL =
  * Plain "asc"/"desc" values fall back to the default name-based sort.
  */
 const FACILITY_SORT_OPTIONS = [
-  { label: 'Overall Rating', value: 'overall_rating:desc' },
-  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
-  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
-  { label: 'Operating Margin', value: 'operating_margin:desc' },
   { label: 'Name (A–Z)', value: 'asc' },
   { label: 'Name (Z–A)', value: 'desc' },
+  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
+  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
+  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
+  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
+  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
+  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
+  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
+  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
 ];
 
 function Facilities() {

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -27,6 +27,21 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 
+/**
+ * Sort options for the facilities browse page.
+ * Rating fields use a compound "field:direction" value so browsePage can split
+ * them into separate `sortBy` and `sort` URL params for the API.
+ * Plain "asc"/"desc" values fall back to the default name-based sort.
+ */
+const FACILITY_SORT_OPTIONS = [
+  { label: 'Overall Rating', value: 'overall_rating:desc' },
+  { label: 'Staffing Rating', value: 'staffing_rating:desc' },
+  { label: 'Health Inspection', value: 'health_inspection_rating:desc' },
+  { label: 'Operating Margin', value: 'operating_margin:desc' },
+  { label: 'Name (A–Z)', value: 'asc' },
+  { label: 'Name (Z–A)', value: 'desc' },
+];
+
 function Facilities() {
   const [searchParams] = useSearchParams();
   const { state } = useLocation();
@@ -40,6 +55,7 @@ function Facilities() {
         title="Nursing Homes"
         searchPlaceholder="Nursing home name..."
         type="facilities"
+        sortOptions={FACILITY_SORT_OPTIONS}
         renderList={(items) => (
           <>
             {chain && (


### PR DESCRIPTION
Adds a new BrowseNursingHomesRatings card component for the facilities browse page. When a field-based sort is active (Overall Rating, Staffing, Health Inspection, or Financial), the standard ownership card is swapped out for this ratings card, which surfaces the four key metrics inline.

BrowseNursingHomesRatings — new card variant in listContainerContent.jsx showing Overall, Health Insp., Staffing, and Financial stat blocks in the card's bottom row
The active sort metric is visually highlighted with a background + border

Depends on: implement_sort_fields