### PR TITLE
Left side update(Merge after 65)

### DIFF
--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -156,7 +156,7 @@ function DistributionView({ data }) {
 function KpiRowView({ data }) {
   const kpis = data.kpis ?? [];
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-2 gap-3">
       {kpis.map((kpi, i) => (
         <div key={i} className="rounded-lg bg-zinc-50 p-3">
           <p className="text-xs text-zinc-500">{kpi.label}</p>
@@ -210,7 +210,10 @@ function TableView({ data }) {
           {rows.map((row, i) => (
             <tr key={i} className="border-b border-zinc-100 last:border-0">
               {columns.map((col, j) => (
-                <td key={col} className="py-2 pr-4 whitespace-nowrap text-zinc-800">
+                <td
+                  key={col}
+                  className="py-2 pr-4 whitespace-nowrap text-zinc-800"
+                >
                   {getCell(row, col, j)}
                 </td>
               ))}

--- a/src/lib/contextChart.js
+++ b/src/lib/contextChart.js
@@ -1,0 +1,93 @@
+/**
+ * Builds the Researcher's on-load "context chart" — a comparison of the subject's
+ * four CMS star ratings against the national average — from data fetched straight
+ * from the URL (see HEF-85).
+ *
+ * The facility and owner endpoints expose the same four ratings under different
+ * field names, so we normalize both into a single internal shape here and emit a
+ * `comparison_bar` chart object consumable by the existing ResearchChart
+ * component — no new chart view required.
+ *
+ * NOTE: the `comparison_bar` output is a baseline. HEF-85's job is the data
+ * pipeline (fetch → normalize → render); the designed on-load charts arrive in
+ * HEF-83, which will change what this emits and/or add new ResearchChart views.
+ * The fetch effect that calls this stays untouched across that work.
+ */
+
+// Per-context field names for the four CMS star ratings on the subject record.
+const RATING_KEYS = {
+  facility: {
+    overall: 'overall_rating',
+    healthInspection: 'health_inspection_rating',
+    staffing: 'staffing_rating',
+    quality: 'quality_rating',
+  },
+  owner: {
+    overall: 'cms_owner_average_overall_rating',
+    healthInspection: 'cms_owner_average_hi_rating',
+    staffing: 'cms_owner_average_staffing_rating',
+    quality: 'cms_owner_average_quality_rating',
+  },
+};
+
+// Field names for the same four ratings on the /national benchmark record.
+const NATIONAL_KEYS = {
+  overall: 'national_overall_rating',
+  healthInspection: 'national_health_inspection_rating',
+  staffing: 'national_staffing_rating',
+  quality: 'national_quality_rating',
+};
+
+// Display order + axis labels, shared by both the subject and national series so
+// the bars line up category-for-category.
+const METRIC_ORDER = ['overall', 'healthInspection', 'staffing', 'quality'];
+const CATEGORY_LABELS = ['Overall', 'Health Inspection', 'Staffing', 'Quality'];
+
+// Star ratings are 1–5; round to one decimal so averaged owner values read cleanly.
+function round(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.round(value * 10) / 10
+    : null;
+}
+
+/**
+ * @param {Object}  args
+ * @param {'facility'|'owner'} args.contextType
+ * @param {Object}  args.subject       - facility or owner record from the data API
+ * @param {Object} [args.national]     - /national benchmark record (optional)
+ * @param {string} [args.subjectName]  - display name for the chart title
+ * @returns {Object|null} a `comparison_bar` chart object, or null if there's
+ *   nothing to plot (unknown context or no subject ratings present).
+ */
+export function buildContextChart({ contextType, subject, national, subjectName }) {
+  const keys = RATING_KEYS[contextType];
+  if (!subject || !keys) return null;
+
+  const subjectValues = METRIC_ORDER.map((metric) => round(subject[keys[metric]]));
+  // Nothing worth charting if the subject has no ratings at all.
+  if (subjectValues.every((value) => value == null)) return null;
+
+  const subjectLabel = contextType === 'owner' ? 'This owner' : 'This facility';
+  const series = [{ name: subjectLabel, values: subjectValues }];
+
+  // National bars are best-effort: include them only when the benchmark fetch
+  // succeeded and carries usable values, otherwise show the subject alone.
+  if (national) {
+    const nationalValues = METRIC_ORDER.map((metric) =>
+      round(national[NATIONAL_KEYS[metric]]),
+    );
+    if (nationalValues.some((value) => value != null)) {
+      series.push({ name: 'National average', values: nationalValues });
+    }
+  }
+
+  const comparesNational = series.length > 1;
+  return {
+    chart_type: 'comparison_bar',
+    title: `${subjectName || subjectLabel} — CMS Star Ratings`,
+    description: comparesNational
+      ? 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5) compared to the national average.'
+      : 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5).',
+    data: { categories: CATEGORY_LABELS, series },
+  };
+}

--- a/src/lib/contextChart.js
+++ b/src/lib/contextChart.js
@@ -1,17 +1,9 @@
 /**
- * Builds the Researcher's on-load "context chart" — a comparison of the subject's
- * four CMS star ratings against the national average — from data fetched straight
- * from the URL (see HEF-85).
+ * Builds the Researcher's on-load context charts from data fetched on mount
+ * Returns an array so multiple charts can be seeded at once — currently a KPI grid and a bar chart .
  *
- * The facility and owner endpoints expose the same four ratings under different
- * field names, so we normalize both into a single internal shape here and emit a
- * `comparison_bar` chart object consumable by the existing ResearchChart
- * component — no new chart view required.
- *
- * NOTE: the `comparison_bar` output is a baseline. HEF-85's job is the data
- * pipeline (fetch → normalize → render); the designed on-load charts arrive in
- * HEF-83, which will change what this emits and/or add new ResearchChart views.
- * The fetch effect that calls this stays untouched across that work.
+ * The facility and owner endpoints expose the same four CMS ratings under
+ * different field names; both are normalized here so callers stay context-agnostic.
  */
 
 // Per-context field names for the four CMS star ratings on the subject record.
@@ -30,20 +22,42 @@ const RATING_KEYS = {
   },
 };
 
-// Field names for the same four ratings on the /national benchmark record.
-const NATIONAL_KEYS = {
-  overall: 'national_overall_rating',
-  healthInspection: 'national_health_inspection_rating',
-  staffing: 'national_staffing_rating',
-  quality: 'national_quality_rating',
+// Benchmark field names by context:
+// - facility: state averages live on the facility record itself
+// - owner: national averages from the /national endpoint (owners span states)
+const BENCHMARK_KEYS = {
+  facility: {
+    overall: 'state_overall_rating',
+    healthInspection: 'state_health_inspection_rating',
+    staffing: 'state_staffing_rating',
+    quality: 'state_quality_rating',
+  },
+  owner: {
+    overall: 'national_overall_rating',
+    healthInspection: 'national_health_inspection_rating',
+    staffing: 'national_staffing_rating',
+    quality: 'national_quality_rating',
+  },
 };
 
-// Display order + axis labels, shared by both the subject and national series so
-// the bars line up category-for-category.
-const METRIC_ORDER = ['overall', 'healthInspection', 'staffing', 'quality'];
-const CATEGORY_LABELS = ['Overall', 'Health Inspection', 'Staffing', 'Quality'];
+// Source of benchmark data by context — facility reads from the subject record
+// itself, owner reads from the separate /national endpoint.
+const BENCHMARK_SOURCE = {
+  facility: 'subject',
+  owner: 'national',
+};
 
-// Star ratings are 1–5; round to one decimal so averaged owner values read cleanly.
+const METRICS = [
+  { key: 'overall', label: 'OVERALL RATING', barLabel: 'Overall' },
+  { key: 'quality', label: 'QUALITY', barLabel: 'Quality' },
+  { key: 'staffing', label: 'STAFFING', barLabel: 'Staffing' },
+  {
+    key: 'healthInspection',
+    label: 'HEALTH INSPECTION',
+    barLabel: 'Health insp.',
+  },
+];
+
 function round(value) {
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.round(value * 10) / 10
@@ -53,41 +67,74 @@ function round(value) {
 /**
  * @param {Object}  args
  * @param {'facility'|'owner'} args.contextType
- * @param {Object}  args.subject       - facility or owner record from the data API
- * @param {Object} [args.national]     - /national benchmark record (optional)
- * @param {string} [args.subjectName]  - display name for the chart title
- * @returns {Object|null} a `comparison_bar` chart object, or null if there's
- *   nothing to plot (unknown context or no subject ratings present).
+ * @param {Object}  args.subject    - facility or owner record from the data API
+ * @param {Object} [args.national]  - /national benchmark record (optional)
+ * @param {string} [args.subjectName]
+ * @returns {Object[]} array of chart objects for ResearchChart: [kpiChart, comparisonChart]
  */
-export function buildContextChart({ contextType, subject, national, subjectName }) {
+export function buildContextCharts({
+  contextType,
+  subject,
+  national,
+  subjectName,
+}) {
   const keys = RATING_KEYS[contextType];
-  if (!subject || !keys) return null;
-
-  const subjectValues = METRIC_ORDER.map((metric) => round(subject[keys[metric]]));
-  // Nothing worth charting if the subject has no ratings at all.
-  if (subjectValues.every((value) => value == null)) return null;
+  if (!subject || !keys) return [];
 
   const subjectLabel = contextType === 'owner' ? 'This owner' : 'This facility';
-  const series = [{ name: subjectLabel, values: subjectValues }];
+  const benchmarkKeys = BENCHMARK_KEYS[contextType];
+  // Facility: state averages are on the subject record. Owner: from /national.
+  const benchmarkSource =
+    BENCHMARK_SOURCE[contextType] === 'subject' ? subject : national;
+  const benchmarkLabel =
+    contextType === 'facility' ? 'State avg' : 'National avg';
+  const comparisonTitle =
+    contextType === 'facility'
+      ? 'CMS Star Ratings vs. State Average'
+      : 'CMS Star Ratings vs. National Average';
 
-  // National bars are best-effort: include them only when the benchmark fetch
-  // succeeded and carries usable values, otherwise show the subject alone.
-  if (national) {
-    const nationalValues = METRIC_ORDER.map((metric) =>
-      round(national[NATIONAL_KEYS[metric]]),
-    );
-    if (nationalValues.some((value) => value != null)) {
-      series.push({ name: 'National average', values: nationalValues });
-    }
-  }
+  // Normalize all four metric values once; shared by both charts below.
+  const normalized = METRICS.map(({ key, label, barLabel }) => {
+    const value = round(subject[keys[key]]);
+    const benchmark = benchmarkSource
+      ? round(benchmarkSource[benchmarkKeys[key]])
+      : null;
+    return { key, label, barLabel, value, benchmark };
+  });
 
-  const comparesNational = series.length > 1;
-  return {
-    chart_type: 'comparison_bar',
+  const kpis = normalized
+    .filter(({ value }) => value != null)
+    .map(({ label, value, benchmark }) => ({
+      label,
+      value: value.toFixed(1),
+      ...(benchmark != null ? { delta: `${benchmarkLabel} ${benchmark.toFixed(1)}` } : {}),
+    }));
+
+  if (!kpis.length) return [];
+
+  const kpiChart = {
+    chart_type: 'kpi_row',
     title: `${subjectName || subjectLabel} — CMS Star Ratings`,
-    description: comparesNational
-      ? 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5) compared to the national average.'
-      : 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5).',
-    data: { categories: CATEGORY_LABELS, series },
+    data: { kpis },
   };
+
+  const subjectValues = normalized.map(({ value }) => value);
+  const benchmarkValues = normalized.map(({ benchmark }) => benchmark);
+  const hasBenchmark = benchmarkValues.some((v) => v != null);
+
+  const comparisonChart = {
+    chart_type: 'comparison_bar',
+    title: comparisonTitle,
+    data: {
+      categories: normalized.map(({ barLabel }) => barLabel),
+      series: [
+        { name: subjectLabel, values: subjectValues },
+        ...(hasBenchmark
+          ? [{ name: benchmarkLabel, values: benchmarkValues }]
+          : []),
+      ],
+    },
+  };
+
+  return [kpiChart, comparisonChart];
 }

--- a/src/lib/researchPrompts.js
+++ b/src/lib/researchPrompts.js
@@ -1,0 +1,20 @@
+/**
+ * Suggested prompt pills displayed on the Researcher pre-chat screen (HeftiResearch.jsx).
+ * Clicking a pill fires the prompt directly into the chat.
+ * Keep owner and facility sets separate — context type is derived from the URL.
+ */
+export const OWNER_PROMPTS = [
+  'Show star rating distribution across this owner\'s facilities',
+  'Which facilities in this portfolio have the most deficiencies?',
+  'Compare this owner\'s average metrics to the national average',
+  'Show staffing turnover rates across this owner\'s facilities',
+  'Which states does this owner operate in and how many facilities per state?',
+];
+
+export const FACILITY_PROMPTS = [
+  'How does this facility\'s star rating compare to the state average?',
+  'What are the most recent deficiencies at this facility?',
+  'How does staffing here compare to national benchmarks?',
+  'Show the clinical quality measures for this facility',
+  'Who owns this facility and what other facilities do they operate?',
+];

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -263,7 +263,7 @@ export default function HeftiResearch() {
       const topOffset = messageRect.top - containerRect.top;
 
       container.scrollTo({
-        top: container.scrollTop + topOffset,
+        top: container.scrollTop + topOffset - 24,
         behavior: 'auto',
       });
     });

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
@@ -24,9 +24,22 @@ const API_BASE_URL =
  *   Fetch ReadableStream API and renders them with react-markdown.
  * - Keeps a rolling history of the last 20 messages to support multi-turn
  *   conversation without unbounded context growth.
- * - Uses `flushSync` + `requestAnimationFrame` to scroll the latest user
- *   bubble to the top of the viewport immediately after send, before the
- *   assistant has produced any output.
+ *
+ * Scroll behavior — both panels pin the newest content to the top of their
+ * viewport so each turn starts from the top, but they do it differently because
+ * of *when* their anchor element exists:
+ *
+ * - Left (chat): the anchor is the user's message, which exists the instant they
+ *   hit send. So we pin it SYNCHRONOUSLY inside submitPrompt — `flushSync` commits
+ *   the message, then a single `requestAnimationFrame` scrolls it to the top.
+ *   Room to scroll is made by giving the latest assistant bubble a min-height
+ *   (`assistantMinHeight`) equal to ~one viewport.
+ * - Right (charts): the anchor is the turn's first chart, which does NOT exist at
+ *   send time — charts stream in asynchronously over the response. So we pin
+ *   REACTIVELY in a `useEffect` keyed on `charts`, scrolling once that first chart
+ *   arrives. Room to scroll is made by a trailing spacer (`chartsSpacerHeight`)
+ *   sized to the right panel's full height, which also survives the brief window
+ *   before Recharts has measured the incoming chart.
  *
  * Route params:
  *  - slug: string — the owner or facility slug, forwarded to the API for context.
@@ -46,14 +59,24 @@ export default function HeftiResearch() {
   const [messages, setMessages] = useState([]);
   const [charts, setCharts] = useState([]);
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
+  const [chartsSpacerHeight, setChartsSpacerHeight] = useState(0);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
+  const chartsPanelRef = useRef(null);
+  // Mirrors lastUserMsgRef on the left: the first chart produced by the current
+  // turn, which we pin to the top of the panel once it arrives.
+  const turnFirstChartRef = useRef(null);
+  // The index the current turn's first chart will occupy, snapshotted at submit
+  // (before any new charts have streamed in).
+  const turnStartIndexRef = useRef(null);
   const hasStarted = messages.length > 0;
 
-  // Tracks the height of the scroll container so we can give the incoming assistant
-  // message bubble enough min-height to fill the remaining viewport. This ensures
-  // there's always enough scroll depth to push the user message to the top of the
-  // view when a new message is sent, even before the assistant has streamed any content.
+  // Left side (chat): tracks the height of the scroll container so we can give the
+  // incoming assistant message bubble enough min-height to fill the remaining
+  // viewport. This ensures there's always enough scroll depth to push the user
+  // message to the top of the view when a new message is sent, even before the
+  // assistant has streamed any content. (The right panel's equivalent spacer
+  // measurement is the next effect below.)
   useLayoutEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
@@ -69,6 +92,52 @@ export default function HeftiResearch() {
 
     return () => resizeObserver.disconnect();
   }, [hasStarted]);
+
+  // Right-panel equivalent of the spacer measurement above. We track the chart
+  // panel's own full height (it's taller than the left container, which excludes
+  // the composer) and use it as a trailing spacer. Sizing the spacer to a full
+  // viewport guarantees there's enough scroll depth to pin a new turn's first
+  // chart to the top even during the brief window before Recharts has measured
+  // and laid out the chart (when it still reports near-zero height).
+  useLayoutEffect(() => {
+    const panel = chartsPanelRef.current;
+    if (!panel) return;
+
+    function updateChartsSpacerHeight() {
+      setChartsSpacerHeight(panel.clientHeight);
+    }
+
+    updateChartsSpacerHeight();
+
+    const resizeObserver = new ResizeObserver(updateChartsSpacerHeight);
+    resizeObserver.observe(panel);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  // Right-panel counterpart to the left side's scroll-to-top (see the scroll block
+  // in submitPrompt). Unlike the left — which pins synchronously at send time
+  // because the user message already exists — charts stream in asynchronously, so
+  // we must pin REACTIVELY here: this effect fires when `charts` changes and acts
+  // only when the turn's first chart has just arrived (length === startIdx + 1),
+  // scrolling it to the top. The trailing spacer in the render guarantees enough
+  // scroll depth below it, exactly how assistantMinHeight makes room on the left.
+  useEffect(() => {
+    const panel = chartsPanelRef.current;
+    const startIdx = turnStartIndexRef.current;
+    if (!panel || startIdx === null || charts.length !== startIdx + 1) return;
+
+    requestAnimationFrame(() => {
+      const chart = turnFirstChartRef.current;
+      if (!panel || !chart) return;
+
+      const panelRect = panel.getBoundingClientRect();
+      const chartRect = chart.getBoundingClientRect();
+      const topOffset = chartRect.top - panelRect.top;
+
+      panel.scrollTo({ top: panel.scrollTop + topOffset, behavior: 'smooth' });
+    });
+  }, [charts]);
 
   async function submitPrompt() {
     const trimmedPrompt = prompt.trim();
@@ -89,7 +158,7 @@ export default function HeftiResearch() {
       isError: false,
     };
 
-    setCharts([]);
+    turnStartIndexRef.current = charts.length;
 
     // flushSync forces React to commit the new messages to the DOM synchronously
     // before we proceed. Without this, the requestAnimationFrame below would run
@@ -104,6 +173,11 @@ export default function HeftiResearch() {
     // sits at the top of the viewport. We use requestAnimationFrame to wait one
     // paint cycle, ensuring layout is complete and getBoundingClientRect() returns
     // accurate values before we calculate the scroll offset.
+    //
+    // This is the SYNCHRONOUS counterpart to the right panel's pin-to-top. We can
+    // do it inline here because the anchor (the user message) already exists after
+    // the flushSync above. The right panel can't — its charts arrive later over
+    // the stream — so it pins reactively in the `charts` useEffect instead.
     requestAnimationFrame(() => {
       const container = messagesContainerRef.current;
       const lastUserMessage = lastUserMsgRef.current;
@@ -147,6 +221,10 @@ export default function HeftiResearch() {
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
+      // DEBUG-ONLY: finalText/finalCharts exist solely to feed the debug log at
+      // the end of the stream loop. The UI is driven by setMessages/setCharts,
+      // not these. Remove these two declarations and their accumulation lines
+      // below when the debug console.log is removed.
       let finalText = '';
       const finalCharts = [];
       let lineBuffer = '';
@@ -196,6 +274,8 @@ export default function HeftiResearch() {
         }
       }
 
+      // DEBUG-ONLY: remove before production. Removing this also makes finalText
+      // and finalCharts (declared above) dead code — delete them together.
       console.log('[researcher] final response:', { text: finalText, charts: finalCharts });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
@@ -291,10 +371,25 @@ export default function HeftiResearch() {
 
         {/* Right panel — chart output */}
         <section className="flex min-h-0 flex-col bg-white">
-          <div className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
+          <div ref={chartsPanelRef} className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
             {charts.map((chart, i) => (
-              <ResearchChart key={i} chart={chart} />
+              <div
+                key={i}
+                ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+              >
+                <ResearchChart chart={chart} />
+              </div>
             ))}
+            {/* Trailing spacer — guarantees enough scroll depth to pin a new
+                turn's first chart to the top, mirroring assistantMinHeight on
+                the left panel. Sized to the panel's full height so the pin works
+                even before Recharts has laid out the incoming chart. */}
+            {charts.length > 0 && (
+              <div
+                aria-hidden="true"
+                style={{ minHeight: `${chartsSpacerHeight}px` }}
+              />
+            )}
           </div>
         </section>
       </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
-import { buildContextChart } from '../lib/contextChart';
+import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 
 const API_BASE_URL =
@@ -36,6 +36,8 @@ const DATA_API_BASE_URL =
  *   Fetch ReadableStream API and renders them with react-markdown.
  * - Keeps a rolling history of the last 20 messages to support multi-turn
  *   conversation without unbounded context growth.
+ * - Seeds the right panel with on-load context charts (KPI + comparison bar)
+ *   fetched on mount before the user sends any messages.
  *
  * Scroll behavior — both panels pin the newest content to the top of their
  * viewport so each turn starts from the top, but they do it differently because
@@ -82,6 +84,9 @@ export default function HeftiResearch() {
   // The index the current turn's first chart will occupy, snapshotted at submit
   // (before any new charts have streamed in).
   const turnStartIndexRef = useRef(null);
+  // Count of on-load context charts — used to position the session-start divider
+  // between the baseline charts and the first AI-generated chart.
+  const contextChartCountRef = useRef(0);
   const hasStarted = messages.length > 0;
 
   // On-load context chart: fetch the subject + national ratings from the
@@ -114,15 +119,18 @@ export default function HeftiResearch() {
           contextType === 'owner'
             ? toTitleCase(subject.cms_ownership_name)
             : subject.provider_name;
-        // Normalizes the differing facility/owner rating fields into a single
-        // `comparison_bar` chart (subject vs. national). See lib/contextChart.
-        const chart = buildContextChart({
+        // Normalizes the differing facility/owner rating fields into context
+        // charts (KPI grid + bar). See lib/contextChart.
+        const contextCharts = buildContextCharts({
           contextType,
           subject,
           national,
           subjectName,
         });
-        if (chart) setCharts((prev) => (prev.length ? prev : [chart]));
+        if (contextCharts.length) {
+          contextChartCountRef.current = contextCharts.length;
+          setCharts((prev) => (prev.length ? prev : contextCharts));
+        }
       })
       // The on-load chart is non-critical; leave the panel empty on failure.
       .catch(() => {});
@@ -452,13 +460,26 @@ export default function HeftiResearch() {
             aria-live="polite"
             className="mr-auto flex h-full w-full max-w-[600px] flex-col space-y-4 overflow-y-auto p-6"
           >
+            {!hasStarted && charts.length > 0 && (
+              <p className="text-paragraph-sm text-content-secondary pb-2">
+                More visualizations will appear here as you explore.
+              </p>
+            )}
             {charts.map((chart, i) => (
-              <div
-                key={i}
-                ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
-              >
-                <ResearchChart chart={chart} />
-              </div>
+              <React.Fragment key={i}>
+                <div
+                  ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+                >
+                  <ResearchChart chart={chart} />
+                </div>
+                {hasStarted && i === contextChartCountRef.current - 1 && (
+                  <div className="flex items-center gap-3 py-2">
+                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                    <span className="text-paragraph-sm text-content-secondary shrink-0">Session start</span>
+                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                  </div>
+                )}
+              </React.Fragment>
             ))}
             {/* Trailing spacer — guarantees enough scroll depth to pin a new
                 turn's first chart to the top, mirroring assistantMinHeight on

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -127,9 +127,9 @@ export default function HeftiResearch() {
     const startIdx = turnStartIndexRef.current;
     if (!panel || startIdx === null || charts.length !== startIdx + 1) return;
 
-    requestAnimationFrame(() => {
+    const frameId = requestAnimationFrame(() => {
       const chart = turnFirstChartRef.current;
-      if (!panel || !chart) return;
+      if (!chart) return;
 
       const panelRect = panel.getBoundingClientRect();
       const chartRect = chart.getBoundingClientRect();
@@ -137,6 +137,8 @@ export default function HeftiResearch() {
 
       panel.scrollTo({ top: panel.scrollTop + topOffset, behavior: 'smooth' });
     });
+
+    return () => cancelAnimationFrame(frameId);
   }, [charts]);
 
   async function submitPrompt() {
@@ -370,8 +372,17 @@ export default function HeftiResearch() {
         </section>
 
         {/* Right panel — chart output */}
-        <section className="flex min-h-0 flex-col bg-white">
-          <div ref={chartsPanelRef} className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
+        <section
+          aria-label="Generated charts"
+          className="flex min-h-0 flex-col bg-white"
+        >
+          {/* aria-live announces newly streamed charts to screen readers, since
+              they appear without any focus or navigation change. */}
+          <div
+            ref={chartsPanelRef}
+            aria-live="polite"
+            className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4"
+          >
             {charts.map((chart, i) => (
               <div
                 key={i}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -13,6 +13,7 @@ import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
+import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
@@ -104,13 +105,13 @@ export default function HeftiResearch() {
         : `facilities/${slug}`;
 
     Promise.all([
-      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((r) =>
-        r.ok ? r.json() : null,
+      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((response) =>
+        response.ok ? response.json() : null,
       ),
       // National bars are best-effort — resolve to null on failure so the chart
       // can still render the subject's own ratings.
       fetch(`${DATA_API_BASE_URL}/national`)
-        .then((r) => (r.ok ? r.json() : null))
+        .then((response) => (response.ok ? response.json() : null))
         .catch(() => null),
     ])
       .then(([subject, national]) => {
@@ -210,8 +211,10 @@ export default function HeftiResearch() {
     return () => cancelAnimationFrame(frameId);
   }, [charts]);
 
-  async function submitPrompt() {
-    const trimmedPrompt = prompt.trim();
+  async function submitPrompt(override) {
+    const trimmedPrompt = (
+      typeof override === 'string' ? override : prompt
+    ).trim();
     if (!trimmedPrompt) return;
 
     // Snapshot history before touching state
@@ -429,14 +432,35 @@ export default function HeftiResearch() {
                 />
               </>
             ) : (
-              <div className="flex flex-1 flex-col items-center justify-center gap-6">
-                <div className="text-center">
-                  <Heading level={2} className="text-heading-lg mb-2">
+              <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex-1 overflow-y-auto px-6 py-8">
+                  <Heading level={2} className="text-heading-lg mb-1">
                     Hefti Researcher
                   </Heading>
-                  <p className="text-paragraph-lg text-content-secondary">
-                    Ask a question about facilities, owners, or quality data.
+                  <p className="text-paragraph-base text-content-secondary mb-6">
+                    {contextType === 'owner'
+                      ? "Ask a question about this owner's facilities, quality, staffing, or financials."
+                      : "Ask a question about this facility's quality, staffing, deficiencies, or ownership."}
                   </p>
+                  <div className="hidden md:block">
+                    <p className="text-paragraph-sm text-content-secondary mb-3 font-medium">
+                      Try asking
+                    </p>
+                    <div className="flex flex-col items-start gap-2">
+                      {(contextType === 'owner'
+                        ? OWNER_PROMPTS
+                        : FACILITY_PROMPTS
+                      ).map((p) => (
+                        <button
+                          key={p}
+                          onClick={() => submitPrompt(p)}
+                          className="text-paragraph-sm text-core-black border-border-primary bg-core-white cursor-pointer rounded-xl border px-4 py-3 text-left transition-colors hover:bg-zinc-50"
+                        >
+                          {p}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
                 </div>
                 <ResearcherComposer
                   value={prompt}
@@ -468,15 +492,25 @@ export default function HeftiResearch() {
             {charts.map((chart, i) => (
               <React.Fragment key={i}>
                 <div
-                  ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+                  ref={
+                    i === turnStartIndexRef.current ? turnFirstChartRef : null
+                  }
                 >
                   <ResearchChart chart={chart} />
                 </div>
                 {hasStarted && i === contextChartCountRef.current - 1 && (
                   <div className="flex items-center gap-3 py-2">
-                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
-                    <span className="text-paragraph-sm text-content-secondary shrink-0">Session start</span>
-                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                    <div
+                      aria-hidden="true"
+                      className="h-px flex-1 bg-zinc-200"
+                    />
+                    <span className="text-paragraph-sm text-content-secondary shrink-0">
+                      Session start
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      className="h-px flex-1 bg-zinc-200"
+                    />
                   </div>
                 )}
               </React.Fragment>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -5,12 +5,24 @@ import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
 import ReactMarkdown from 'react-markdown';
 import { MdComponents } from '../lib/mdComponents';
-import { getResearchPages, getRankingsResearchPages } from '../lib/breadcrumbPages';
+import {
+  getResearchPages,
+  getRankingsResearchPages,
+} from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
+import { buildContextChart } from '../lib/contextChart';
+import { toTitleCase } from '../lib/toTitleCase';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
+  'http://hefti-data-api.ddev.site:3000/api';
+
+// The researcher stream lives behind VITE_RESEARCHER_FUNCTION_URL, but the
+// on-load context chart pulls subject + national data from the regular data API
+// (the same endpoints the profile pages use), which is a separate env var.
+const DATA_API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 /**
  * HeftiResearch
@@ -51,9 +63,10 @@ export default function HeftiResearch() {
   const contextType = pathname.includes('/owners/') ? 'owner' : 'facility';
 
   // Swaps in rankings breadcrumb trail when arriving via the rankings page.
-  const researchPages = state?.from === 'rankings'
-    ? getRankingsResearchPages(slug, contextType)
-    : getResearchPages(slug, contextType);
+  const researchPages =
+    state?.from === 'rankings'
+      ? getRankingsResearchPages(slug, contextType)
+      : getResearchPages(slug, contextType);
 
   const [prompt, setPrompt] = useState('');
   const [messages, setMessages] = useState([]);
@@ -70,6 +83,54 @@ export default function HeftiResearch() {
   // (before any new charts have streamed in).
   const turnStartIndexRef = useRef(null);
   const hasStarted = messages.length > 0;
+
+  // On-load context chart: fetch the subject + national ratings from the
+  // URL and seed a comparison chart into the right panel before the user sends
+  // anything. Fetching keeps it correct on reload/shared links.
+  // The `prev.length ? prev : [chart]` guard makes a late fetch a no-op once any
+  // chart exists, so it can't clobber streamed charts.
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+
+    const subjectPath =
+      contextType === 'owner'
+        ? `owners/${encodeURIComponent(slug)}`
+        : `facilities/${slug}`;
+
+    Promise.all([
+      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((r) =>
+        r.ok ? r.json() : null,
+      ),
+      // National bars are best-effort — resolve to null on failure so the chart
+      // can still render the subject's own ratings.
+      fetch(`${DATA_API_BASE_URL}/national`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ])
+      .then(([subject, national]) => {
+        if (cancelled || !subject) return;
+        const subjectName =
+          contextType === 'owner'
+            ? toTitleCase(subject.cms_ownership_name)
+            : subject.provider_name;
+        // Normalizes the differing facility/owner rating fields into a single
+        // `comparison_bar` chart (subject vs. national). See lib/contextChart.
+        const chart = buildContextChart({
+          contextType,
+          subject,
+          national,
+          subjectName,
+        });
+        if (chart) setCharts((prev) => (prev.length ? prev : [chart]));
+      })
+      // The on-load chart is non-critical; leave the panel empty on failure.
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, contextType]);
 
   // Left side (chat): tracks the height of the scroll container so we can give the
   // incoming assistant message bubble enough min-height to fill the remaining
@@ -239,7 +300,9 @@ export default function HeftiResearch() {
         // Accumulate into a line buffer so SSE lines split across TCP chunks are
         // reassembled before parsing. Without this, large chart payloads cause
         // JSON.parse failures when the chunk boundary falls mid-line.
-        lineBuffer += decoder.decode(value ?? new Uint8Array(), { stream: !done });
+        lineBuffer += decoder.decode(value ?? new Uint8Array(), {
+          stream: !done,
+        });
 
         const lines = lineBuffer.split('\n');
         // Keep the last (potentially incomplete) segment in the buffer
@@ -248,7 +311,10 @@ export default function HeftiResearch() {
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
           const payload = line.slice(6);
-          if (payload === '[DONE]') { done = true; break; }
+          if (payload === '[DONE]') {
+            done = true;
+            break;
+          }
 
           const { text, error, chart } = JSON.parse(payload);
 
@@ -278,7 +344,10 @@ export default function HeftiResearch() {
 
       // DEBUG-ONLY: remove before production. Removing this also makes finalText
       // and finalCharts (declared above) dead code — delete them together.
-      console.log('[researcher] final response:', { text: finalText, charts: finalCharts });
+      console.log('[researcher] final response:', {
+        text: finalText,
+        charts: finalCharts,
+      });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
     }
@@ -381,7 +450,7 @@ export default function HeftiResearch() {
           <div
             ref={chartsPanelRef}
             aria-live="polite"
-            className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4"
+            className="mr-auto flex h-full w-full max-w-[600px] flex-col space-y-4 overflow-y-auto p-6"
           >
             {charts.map((chart, i) => (
               <div


### PR DESCRIPTION
**Redesign of the left side initial load state**

- Adds src/lib/researchPrompts.js with separate prompt sets for owner and facility contexts (5 prompts each), imported by HeftiResearch
- Redesigns the Researcher pre-chat view: static "Hefti Researcher" heading with context-aware subtitle, composer anchored to the bottom of the screen instead of centered
- Adds a "Try asking" pill section — clicking any pill fires the prompt directly into the LLM without typing; pills are hidden below md breakpoint and sized to their text content
- Fixes a scroll bug where multi-line user query bubbles were pinning flush against the breadcrumb on submit