### PR TITLE
Design token pass (MERGE AFTER 66)

### DIFF
--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -156,7 +156,7 @@ function DistributionView({ data }) {
 function KpiRowView({ data }) {
   const kpis = data.kpis ?? [];
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+    <div className="grid grid-cols-2 gap-3">
       {kpis.map((kpi, i) => (
         <div key={i} className="rounded-lg bg-zinc-50 p-3">
           <p className="text-xs text-zinc-500">{kpi.label}</p>
@@ -210,7 +210,10 @@ function TableView({ data }) {
           {rows.map((row, i) => (
             <tr key={i} className="border-b border-zinc-100 last:border-0">
               {columns.map((col, j) => (
-                <td key={col} className="py-2 pr-4 whitespace-nowrap text-zinc-800">
+                <td
+                  key={col}
+                  className="py-2 pr-4 whitespace-nowrap text-zinc-800"
+                >
                   {getCell(row, col, j)}
                 </td>
               ))}

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   BarChart,
   Bar,
@@ -21,10 +22,11 @@ const COLORS = [
   '#0891b2',
 ];
 
+//The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
 function ChartWrapper({ title, description, children }) {
   return (
-    <div className="rounded-xl border border-zinc-200 p-4">
-      <p className="text-paragraph-sm text-core-black font-semibold">{title}</p>
+    <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
+      <p className="text-label-lg text-core-black">{title}</p>
       {description && (
         <p className="text-paragraph-sm text-content-secondary mt-1">
           {description}
@@ -34,6 +36,12 @@ function ChartWrapper({ title, description, children }) {
     </div>
   );
 }
+
+ChartWrapper.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
 
 function BarView({ data }) {
   const bars = data.bars ?? data.items ?? [];
@@ -62,6 +70,13 @@ function BarView({ data }) {
     </ResponsiveContainer>
   );
 }
+
+BarView.propTypes = {
+  data: PropTypes.shape({
+    bars: PropTypes.arrayOf(PropTypes.object),
+    items: PropTypes.arrayOf(PropTypes.object),
+  }).isRequired,
+};
 
 function ComparisonBarView({ data }) {
   const { categories = [], series = [] } = data;
@@ -102,6 +117,19 @@ function ComparisonBarView({ data }) {
   );
 }
 
+ComparisonBarView.propTypes = {
+  data: PropTypes.shape({
+    categories: PropTypes.arrayOf(PropTypes.string),
+    series: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        values: PropTypes.arrayOf(PropTypes.number),
+        data: PropTypes.arrayOf(PropTypes.number),
+      }),
+    ),
+  }).isRequired,
+};
+
 function ScatterView({ data }) {
   const points = data.points ?? [];
   return (
@@ -124,6 +152,14 @@ function ScatterView({ data }) {
     </ResponsiveContainer>
   );
 }
+
+ScatterView.propTypes = {
+  data: PropTypes.shape({
+    points: PropTypes.arrayOf(PropTypes.object),
+    xLabel: PropTypes.string,
+    yLabel: PropTypes.string,
+  }).isRequired,
+};
 
 function DistributionView({ data }) {
   const bins = data.bins ?? data.bars ?? data.items ?? [];
@@ -153,29 +189,55 @@ function DistributionView({ data }) {
   );
 }
 
+DistributionView.propTypes = {
+  data: PropTypes.shape({
+    bins: PropTypes.arrayOf(PropTypes.object),
+    bars: PropTypes.arrayOf(PropTypes.object),
+    items: PropTypes.arrayOf(PropTypes.object),
+  }).isRequired,
+};
+
 function KpiRowView({ data }) {
   const kpis = data.kpis ?? [];
   return (
     <div className="grid grid-cols-2 gap-3">
       {kpis.map((kpi, i) => (
-        <div key={i} className="rounded-lg bg-zinc-50 p-3">
-          <p className="text-xs text-zinc-500">{kpi.label}</p>
-          <p className="mt-1 text-xl font-semibold text-zinc-900">
+        <div
+          key={i}
+          className="bg-core-white border-border-primary rounded-md border p-3 shadow-sm"
+        >
+          <p className="text-core-black mt-1 text-xl font-semibold">
             {kpi.value}
             {kpi.unit ? (
-              <span className="ml-1 text-sm font-normal text-zinc-500">
+              <span className="text-content-secondary text-label-sm ml-1">
                 {kpi.unit}
               </span>
             ) : null}
           </p>
+          <p className="text-core-black text-label-sm">{kpi.label}</p>
           {kpi.delta && (
-            <p className="mt-0.5 text-xs text-zinc-400">{kpi.delta}</p>
+            <p className="text-content-secondary text-label-sm mt-0.5">
+              {kpi.delta}
+            </p>
           )}
         </div>
       ))}
     </div>
   );
 }
+
+KpiRowView.propTypes = {
+  data: PropTypes.shape({
+    kpis: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string,
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        unit: PropTypes.string,
+        delta: PropTypes.string,
+      }),
+    ),
+  }).isRequired,
+};
 
 function TableView({ data }) {
   const rows = data.rows ?? [];
@@ -225,6 +287,13 @@ function TableView({ data }) {
   );
 }
 
+TableView.propTypes = {
+  data: PropTypes.shape({
+    rows: PropTypes.array.isRequired,
+    columns: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+};
+
 const VIEWS = {
   bar: BarView,
   comparison_bar: ComparisonBarView,
@@ -244,3 +313,12 @@ export default function ResearchChart({ chart }) {
     </ChartWrapper>
   );
 }
+
+ResearchChart.propTypes = {
+  chart: PropTypes.shape({
+    chart_type: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    data: PropTypes.object.isRequired,
+  }).isRequired,
+};

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -35,8 +35,8 @@ import {
 // Recharts accepts only hex/rgb — CSS variables are not supported in its prop
 // system. These constants are manually kept in sync with the Hefti tokens they
 // correspond to; update both if the design system palette changes.
-const CHART_GRID_COLOR = '#e4e4e7'; // --border-primary  (zinc-200)
-const CHART_AXIS_COLOR = '#71717a'; // --content-secondary (zinc-500)
+const CHART_GRID_COLOR = '#71717a'; // --content-secondary (zinc-500)
+const CHART_AXIS_COLOR = '#09090b'; // --content-primary (zinc-950)
 // SVG text does not inherit CSS font-family — Inter must be set explicitly.
 const CHART_TICK_STYLE = {
   fontSize: 11,
@@ -45,8 +45,8 @@ const CHART_TICK_STYLE = {
 };
 
 const COLORS = [
-  '#7c3aed', // violet-600 — home page accent, subject series (This owner / This facility)
-  '#60a5fa', // blue-400   — home page accent, benchmark series (National avg / State avg)
+  '#60a5fa', // blue-400   — home page accent, subject series (This owner / This facility)
+  '#7c3aed', // violet-600 — home page accent, benchmark series (National avg / State avg)
   '#0891b2', // cyan-600   — tertiary series
 ];
 

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -37,6 +37,12 @@ import {
 // correspond to; update both if the design system palette changes.
 const CHART_GRID_COLOR = '#e4e4e7'; // --border-primary  (zinc-200)
 const CHART_AXIS_COLOR = '#71717a'; // --content-secondary (zinc-500)
+// SVG text does not inherit CSS font-family — Inter must be set explicitly.
+const CHART_TICK_STYLE = {
+  fontSize: 11,
+  fill: CHART_AXIS_COLOR,
+  fontFamily: 'Inter, sans-serif',
+};
 
 const COLORS = [
   '#7c3aed', // violet-600 — home page accent, subject series (This owner / This facility)
@@ -50,7 +56,7 @@ function ChartWrapper({ title, description, children }) {
     <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
       <p className="text-label-lg text-core-black">{title}</p>
       {description && (
-        <p className="text-paragraph-sm text-content-secondary mt-1">
+        <p className="text-paragraph-base text-content-secondary mt-1">
           {description}
         </p>
       )}
@@ -80,12 +86,12 @@ function BarView({ data }) {
         <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="label"
-          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
+          tick={CHART_TICK_STYLE}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
+        <YAxis tick={CHART_TICK_STYLE} />
         <Tooltip />
         <Bar dataKey="value" fill={COLORS[0]} radius={[3, 3, 0, 0]} />
       </BarChart>
@@ -118,14 +124,14 @@ function ComparisonBarView({ data }) {
         <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="category"
-          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
+          tick={CHART_TICK_STYLE}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
+        <YAxis tick={CHART_TICK_STYLE} />
         <Tooltip />
-        <Legend verticalAlign="top" />
+        <Legend verticalAlign="top" wrapperStyle={{ paddingBottom: '12px' }} />
         {series.map((s, i) => (
           <Bar
             key={s.name}
@@ -158,16 +164,8 @@ function ScatterView({ data }) {
     <ResponsiveContainer width="100%" height={260}>
       <ScatterChart margin={{ top: 4, right: 8, left: 0, bottom: 8 }}>
         <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
-        <XAxis
-          dataKey="x"
-          name={data.xLabel ?? 'x'}
-          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
-        />
-        <YAxis
-          dataKey="y"
-          name={data.yLabel ?? 'y'}
-          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
-        />
+        <XAxis dataKey="x" name={data.xLabel ?? 'x'} tick={CHART_TICK_STYLE} />
+        <YAxis dataKey="y" name={data.yLabel ?? 'y'} tick={CHART_TICK_STYLE} />
         <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         <Scatter data={points} fill={COLORS[0]} />
       </ScatterChart>
@@ -198,12 +196,12 @@ function DistributionView({ data }) {
         <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="label"
-          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
+          tick={CHART_TICK_STYLE}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
+        <YAxis tick={CHART_TICK_STYLE} />
         <Tooltip />
         <Bar dataKey="value" fill={COLORS[1]} radius={[3, 3, 0, 0]} />
       </BarChart>
@@ -228,7 +226,8 @@ function KpiRowView({ data }) {
           key={i}
           className="border-border-primary bg-background-secondary rounded-md border p-3 shadow-sm"
         >
-          <p className="text-core-black mt-1 text-xl font-semibold">
+          <p className="text-core-black text-label-base">{kpi.label}</p>
+          <p className="text-core-black text-heading-xs mt-1">
             {kpi.value}
             {kpi.unit ? (
               <span className="text-content-secondary text-label-sm ml-1">
@@ -236,9 +235,9 @@ function KpiRowView({ data }) {
               </span>
             ) : null}
           </p>
-          <p className="text-core-black text-label-sm">{kpi.label}</p>
+
           {kpi.delta && (
-            <p className="text-content-secondary text-label-sm mt-0.5">
+            <p className="text-content-secondary text-label-base mt-0.5">
               {kpi.delta}
             </p>
           )}

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -13,13 +13,35 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
+/**
+ * ResearchChart — chart rendering for the Hefti Researcher right panel.
+ *
+ * This file houses all Recharts-based view components used in the Researcher.
+ * Each view (BarView, ComparisonBarView, ScatterView, DistributionView,
+ * KpiRowView, TableView) handles one chart type and receives a `data` prop
+ * shaped to its needs. Views are internal — they are never rendered directly.
+ *
+ * The VIEWS registry maps `chart_type` strings from the API response to their
+ * view component. The exported `ResearchChart` component is the single entry
+ * point: it receives a chart object, looks up the right view from the registry,
+ * and wraps it in ChartWrapper (the shared card shell with title and border).
+ *
+ * To add a new chart type: build a view component, add it to VIEWS, and the
+ * LLM response just needs to return the matching `chart_type` key. New view
+ * components must use Hefti design tokens (colors, typography, spacing) rather
+ * than hardcoded Tailwind zinc/hex values — use existing views as the reference.
+ */
+
+// Recharts accepts only hex/rgb — CSS variables are not supported in its prop
+// system. These constants are manually kept in sync with the Hefti tokens they
+// correspond to; update both if the design system palette changes.
+const CHART_GRID_COLOR = '#e4e4e7'; // --border-primary  (zinc-200)
+const CHART_AXIS_COLOR = '#71717a'; // --content-secondary (zinc-500)
+
 const COLORS = [
-  '#2563eb',
-  '#16a34a',
-  '#dc2626',
-  '#d97706',
-  '#7c3aed',
-  '#0891b2',
+  '#7c3aed', // violet-600 — home page accent, subject series (This owner / This facility)
+  '#60a5fa', // blue-400   — home page accent, benchmark series (National avg / State avg)
+  '#0891b2', // cyan-600   — tertiary series
 ];
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
@@ -55,15 +77,15 @@ function BarView({ data }) {
         data={normalized}
         margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
       >
-        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="label"
-          tick={{ fontSize: 11, fill: '#71717a' }}
+          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
         <Tooltip />
         <Bar dataKey="value" fill={COLORS[0]} radius={[3, 3, 0, 0]} />
       </BarChart>
@@ -93,17 +115,17 @@ function ComparisonBarView({ data }) {
         data={normalized}
         margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
       >
-        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="category"
-          tick={{ fontSize: 11, fill: '#71717a' }}
+          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
         <Tooltip />
-        <Legend />
+        <Legend verticalAlign="top" />
         {series.map((s, i) => (
           <Bar
             key={s.name}
@@ -135,16 +157,16 @@ function ScatterView({ data }) {
   return (
     <ResponsiveContainer width="100%" height={260}>
       <ScatterChart margin={{ top: 4, right: 8, left: 0, bottom: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="x"
           name={data.xLabel ?? 'x'}
-          tick={{ fontSize: 11, fill: '#71717a' }}
+          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
         />
         <YAxis
           dataKey="y"
           name={data.yLabel ?? 'y'}
-          tick={{ fontSize: 11, fill: '#71717a' }}
+          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
         />
         <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         <Scatter data={points} fill={COLORS[0]} />
@@ -173,15 +195,15 @@ function DistributionView({ data }) {
         data={normalized}
         margin={{ top: 4, right: 8, left: 0, bottom: 40 }}
       >
-        <CartesianGrid strokeDasharray="3 3" stroke="#e4e4e7" />
+        <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_COLOR} />
         <XAxis
           dataKey="label"
-          tick={{ fontSize: 11, fill: '#71717a' }}
+          tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }}
           angle={-35}
           textAnchor="end"
           interval={0}
         />
-        <YAxis tick={{ fontSize: 11, fill: '#71717a' }} />
+        <YAxis tick={{ fontSize: 11, fill: CHART_AXIS_COLOR }} />
         <Tooltip />
         <Bar dataKey="value" fill={COLORS[1]} radius={[3, 3, 0, 0]} />
       </BarChart>
@@ -204,7 +226,7 @@ function KpiRowView({ data }) {
       {kpis.map((kpi, i) => (
         <div
           key={i}
-          className="bg-core-white border-border-primary rounded-md border p-3 shadow-sm"
+          className="border-border-primary bg-background-secondary rounded-md border p-3 shadow-sm"
         >
           <p className="text-core-black mt-1 text-xl font-semibold">
             {kpi.value}
@@ -255,13 +277,13 @@ function TableView({ data }) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-left text-xs">
+      <table className="text-paragraph-xs w-full text-left">
         <thead>
-          <tr className="border-b border-zinc-200">
+          <tr className="border-border-primary border-b">
             {columns.map((col) => (
               <th
                 key={col}
-                className="pr-4 pb-2 font-semibold whitespace-nowrap text-zinc-500 capitalize"
+                className="text-label-sm pr-4 pb-2 whitespace-nowrap capitalize"
               >
                 {String(col).replace(/_/g, ' ')}
               </th>
@@ -270,11 +292,14 @@ function TableView({ data }) {
         </thead>
         <tbody>
           {rows.map((row, i) => (
-            <tr key={i} className="border-b border-zinc-100 last:border-0">
+            <tr
+              key={i}
+              className="border-border-secondary border-b last:border-0"
+            >
               {columns.map((col, j) => (
                 <td
                   key={col}
-                  className="py-2 pr-4 whitespace-nowrap text-zinc-800"
+                  className="text-content-tertiary py-2 pr-4 whitespace-nowrap"
                 >
                   {getCell(row, col, j)}
                 </td>
@@ -294,6 +319,9 @@ TableView.propTypes = {
   }).isRequired,
 };
 
+// Registry mapping chart_type strings (from the API response) to their view
+// components. To add a new chart type: create a view component above, add it
+// here, and the LLM response just needs to include the matching chart_type key.
 const VIEWS = {
   bar: BarView,
   comparison_bar: ComparisonBarView,
@@ -303,6 +331,9 @@ const VIEWS = {
   table: TableView,
 };
 
+// Entry point — receives a single chart object, looks up the right view from
+// the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
+// chart types so unrecognized LLM output fails silently rather than crashing.
 export default function ResearchChart({ chart }) {
   const { chart_type, title, description, data } = chart;
   const View = VIEWS[chart_type];

--- a/src/lib/contextChart.js
+++ b/src/lib/contextChart.js
@@ -48,12 +48,12 @@ const BENCHMARK_SOURCE = {
 };
 
 const METRICS = [
-  { key: 'overall', label: 'OVERALL RATING', barLabel: 'Overall' },
-  { key: 'quality', label: 'QUALITY', barLabel: 'Quality' },
-  { key: 'staffing', label: 'STAFFING', barLabel: 'Staffing' },
+  { key: 'overall', label: 'Overall Rating', barLabel: 'Overall' },
+  { key: 'quality', label: 'Quality', barLabel: 'Quality' },
+  { key: 'staffing', label: 'Staffing', barLabel: 'Staffing' },
   {
     key: 'healthInspection',
-    label: 'HEALTH INSPECTION',
+    label: 'Health Inspection',
     barLabel: 'Health insp.',
   },
 ];

--- a/src/lib/contextChart.js
+++ b/src/lib/contextChart.js
@@ -1,0 +1,93 @@
+/**
+ * Builds the Researcher's on-load "context chart" — a comparison of the subject's
+ * four CMS star ratings against the national average — from data fetched straight
+ * from the URL (see HEF-85).
+ *
+ * The facility and owner endpoints expose the same four ratings under different
+ * field names, so we normalize both into a single internal shape here and emit a
+ * `comparison_bar` chart object consumable by the existing ResearchChart
+ * component — no new chart view required.
+ *
+ * NOTE: the `comparison_bar` output is a baseline. HEF-85's job is the data
+ * pipeline (fetch → normalize → render); the designed on-load charts arrive in
+ * HEF-83, which will change what this emits and/or add new ResearchChart views.
+ * The fetch effect that calls this stays untouched across that work.
+ */
+
+// Per-context field names for the four CMS star ratings on the subject record.
+const RATING_KEYS = {
+  facility: {
+    overall: 'overall_rating',
+    healthInspection: 'health_inspection_rating',
+    staffing: 'staffing_rating',
+    quality: 'quality_rating',
+  },
+  owner: {
+    overall: 'cms_owner_average_overall_rating',
+    healthInspection: 'cms_owner_average_hi_rating',
+    staffing: 'cms_owner_average_staffing_rating',
+    quality: 'cms_owner_average_quality_rating',
+  },
+};
+
+// Field names for the same four ratings on the /national benchmark record.
+const NATIONAL_KEYS = {
+  overall: 'national_overall_rating',
+  healthInspection: 'national_health_inspection_rating',
+  staffing: 'national_staffing_rating',
+  quality: 'national_quality_rating',
+};
+
+// Display order + axis labels, shared by both the subject and national series so
+// the bars line up category-for-category.
+const METRIC_ORDER = ['overall', 'healthInspection', 'staffing', 'quality'];
+const CATEGORY_LABELS = ['Overall', 'Health Inspection', 'Staffing', 'Quality'];
+
+// Star ratings are 1–5; round to one decimal so averaged owner values read cleanly.
+function round(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.round(value * 10) / 10
+    : null;
+}
+
+/**
+ * @param {Object}  args
+ * @param {'facility'|'owner'} args.contextType
+ * @param {Object}  args.subject       - facility or owner record from the data API
+ * @param {Object} [args.national]     - /national benchmark record (optional)
+ * @param {string} [args.subjectName]  - display name for the chart title
+ * @returns {Object|null} a `comparison_bar` chart object, or null if there's
+ *   nothing to plot (unknown context or no subject ratings present).
+ */
+export function buildContextChart({ contextType, subject, national, subjectName }) {
+  const keys = RATING_KEYS[contextType];
+  if (!subject || !keys) return null;
+
+  const subjectValues = METRIC_ORDER.map((metric) => round(subject[keys[metric]]));
+  // Nothing worth charting if the subject has no ratings at all.
+  if (subjectValues.every((value) => value == null)) return null;
+
+  const subjectLabel = contextType === 'owner' ? 'This owner' : 'This facility';
+  const series = [{ name: subjectLabel, values: subjectValues }];
+
+  // National bars are best-effort: include them only when the benchmark fetch
+  // succeeded and carries usable values, otherwise show the subject alone.
+  if (national) {
+    const nationalValues = METRIC_ORDER.map((metric) =>
+      round(national[NATIONAL_KEYS[metric]]),
+    );
+    if (nationalValues.some((value) => value != null)) {
+      series.push({ name: 'National average', values: nationalValues });
+    }
+  }
+
+  const comparesNational = series.length > 1;
+  return {
+    chart_type: 'comparison_bar',
+    title: `${subjectName || subjectLabel} — CMS Star Ratings`,
+    description: comparesNational
+      ? 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5) compared to the national average.'
+      : 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5).',
+    data: { categories: CATEGORY_LABELS, series },
+  };
+}

--- a/src/lib/contextChart.js
+++ b/src/lib/contextChart.js
@@ -1,17 +1,9 @@
 /**
- * Builds the Researcher's on-load "context chart" — a comparison of the subject's
- * four CMS star ratings against the national average — from data fetched straight
- * from the URL (see HEF-85).
+ * Builds the Researcher's on-load context charts from data fetched on mount
+ * Returns an array so multiple charts can be seeded at once — currently a KPI grid and a bar chart .
  *
- * The facility and owner endpoints expose the same four ratings under different
- * field names, so we normalize both into a single internal shape here and emit a
- * `comparison_bar` chart object consumable by the existing ResearchChart
- * component — no new chart view required.
- *
- * NOTE: the `comparison_bar` output is a baseline. HEF-85's job is the data
- * pipeline (fetch → normalize → render); the designed on-load charts arrive in
- * HEF-83, which will change what this emits and/or add new ResearchChart views.
- * The fetch effect that calls this stays untouched across that work.
+ * The facility and owner endpoints expose the same four CMS ratings under
+ * different field names; both are normalized here so callers stay context-agnostic.
  */
 
 // Per-context field names for the four CMS star ratings on the subject record.
@@ -30,20 +22,42 @@ const RATING_KEYS = {
   },
 };
 
-// Field names for the same four ratings on the /national benchmark record.
-const NATIONAL_KEYS = {
-  overall: 'national_overall_rating',
-  healthInspection: 'national_health_inspection_rating',
-  staffing: 'national_staffing_rating',
-  quality: 'national_quality_rating',
+// Benchmark field names by context:
+// - facility: state averages live on the facility record itself
+// - owner: national averages from the /national endpoint (owners span states)
+const BENCHMARK_KEYS = {
+  facility: {
+    overall: 'state_overall_rating',
+    healthInspection: 'state_health_inspection_rating',
+    staffing: 'state_staffing_rating',
+    quality: 'state_quality_rating',
+  },
+  owner: {
+    overall: 'national_overall_rating',
+    healthInspection: 'national_health_inspection_rating',
+    staffing: 'national_staffing_rating',
+    quality: 'national_quality_rating',
+  },
 };
 
-// Display order + axis labels, shared by both the subject and national series so
-// the bars line up category-for-category.
-const METRIC_ORDER = ['overall', 'healthInspection', 'staffing', 'quality'];
-const CATEGORY_LABELS = ['Overall', 'Health Inspection', 'Staffing', 'Quality'];
+// Source of benchmark data by context — facility reads from the subject record
+// itself, owner reads from the separate /national endpoint.
+const BENCHMARK_SOURCE = {
+  facility: 'subject',
+  owner: 'national',
+};
 
-// Star ratings are 1–5; round to one decimal so averaged owner values read cleanly.
+const METRICS = [
+  { key: 'overall', label: 'OVERALL RATING', barLabel: 'Overall' },
+  { key: 'quality', label: 'QUALITY', barLabel: 'Quality' },
+  { key: 'staffing', label: 'STAFFING', barLabel: 'Staffing' },
+  {
+    key: 'healthInspection',
+    label: 'HEALTH INSPECTION',
+    barLabel: 'Health insp.',
+  },
+];
+
 function round(value) {
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.round(value * 10) / 10
@@ -53,41 +67,74 @@ function round(value) {
 /**
  * @param {Object}  args
  * @param {'facility'|'owner'} args.contextType
- * @param {Object}  args.subject       - facility or owner record from the data API
- * @param {Object} [args.national]     - /national benchmark record (optional)
- * @param {string} [args.subjectName]  - display name for the chart title
- * @returns {Object|null} a `comparison_bar` chart object, or null if there's
- *   nothing to plot (unknown context or no subject ratings present).
+ * @param {Object}  args.subject    - facility or owner record from the data API
+ * @param {Object} [args.national]  - /national benchmark record (optional)
+ * @param {string} [args.subjectName]
+ * @returns {Object[]} array of chart objects for ResearchChart: [kpiChart, comparisonChart]
  */
-export function buildContextChart({ contextType, subject, national, subjectName }) {
+export function buildContextCharts({
+  contextType,
+  subject,
+  national,
+  subjectName,
+}) {
   const keys = RATING_KEYS[contextType];
-  if (!subject || !keys) return null;
-
-  const subjectValues = METRIC_ORDER.map((metric) => round(subject[keys[metric]]));
-  // Nothing worth charting if the subject has no ratings at all.
-  if (subjectValues.every((value) => value == null)) return null;
+  if (!subject || !keys) return [];
 
   const subjectLabel = contextType === 'owner' ? 'This owner' : 'This facility';
-  const series = [{ name: subjectLabel, values: subjectValues }];
+  const benchmarkKeys = BENCHMARK_KEYS[contextType];
+  // Facility: state averages are on the subject record. Owner: from /national.
+  const benchmarkSource =
+    BENCHMARK_SOURCE[contextType] === 'subject' ? subject : national;
+  const benchmarkLabel =
+    contextType === 'facility' ? 'State avg' : 'National avg';
+  const comparisonTitle =
+    contextType === 'facility'
+      ? 'CMS Star Ratings vs. State Average'
+      : 'CMS Star Ratings vs. National Average';
 
-  // National bars are best-effort: include them only when the benchmark fetch
-  // succeeded and carries usable values, otherwise show the subject alone.
-  if (national) {
-    const nationalValues = METRIC_ORDER.map((metric) =>
-      round(national[NATIONAL_KEYS[metric]]),
-    );
-    if (nationalValues.some((value) => value != null)) {
-      series.push({ name: 'National average', values: nationalValues });
-    }
-  }
+  // Normalize all four metric values once; shared by both charts below.
+  const normalized = METRICS.map(({ key, label, barLabel }) => {
+    const value = round(subject[keys[key]]);
+    const benchmark = benchmarkSource
+      ? round(benchmarkSource[benchmarkKeys[key]])
+      : null;
+    return { key, label, barLabel, value, benchmark };
+  });
 
-  const comparesNational = series.length > 1;
-  return {
-    chart_type: 'comparison_bar',
+  const kpis = normalized
+    .filter(({ value }) => value != null)
+    .map(({ label, value, benchmark }) => ({
+      label,
+      value: value.toFixed(1),
+      ...(benchmark != null ? { delta: `${benchmarkLabel} ${benchmark.toFixed(1)}` } : {}),
+    }));
+
+  if (!kpis.length) return [];
+
+  const kpiChart = {
+    chart_type: 'kpi_row',
     title: `${subjectName || subjectLabel} — CMS Star Ratings`,
-    description: comparesNational
-      ? 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5) compared to the national average.'
-      : 'Overall, Health Inspection, Staffing, and Quality star ratings (1–5).',
-    data: { categories: CATEGORY_LABELS, series },
+    data: { kpis },
   };
+
+  const subjectValues = normalized.map(({ value }) => value);
+  const benchmarkValues = normalized.map(({ benchmark }) => benchmark);
+  const hasBenchmark = benchmarkValues.some((v) => v != null);
+
+  const comparisonChart = {
+    chart_type: 'comparison_bar',
+    title: comparisonTitle,
+    data: {
+      categories: normalized.map(({ barLabel }) => barLabel),
+      series: [
+        { name: subjectLabel, values: subjectValues },
+        ...(hasBenchmark
+          ? [{ name: benchmarkLabel, values: benchmarkValues }]
+          : []),
+      ],
+    },
+  };
+
+  return [kpiChart, comparisonChart];
 }

--- a/src/lib/researchPrompts.js
+++ b/src/lib/researchPrompts.js
@@ -1,0 +1,20 @@
+/**
+ * Suggested prompt pills displayed on the Researcher pre-chat screen (HeftiResearch.jsx).
+ * Clicking a pill fires the prompt directly into the chat.
+ * Keep owner and facility sets separate — context type is derived from the URL.
+ */
+export const OWNER_PROMPTS = [
+  'Show star rating distribution across this owner\'s facilities',
+  'Which facilities in this portfolio have the most deficiencies?',
+  'Compare this owner\'s average metrics to the national average',
+  'Show staffing turnover rates across this owner\'s facilities',
+  'Which states does this owner operate in and how many facilities per state?',
+];
+
+export const FACILITY_PROMPTS = [
+  'How does this facility\'s star rating compare to the state average?',
+  'What are the most recent deficiencies at this facility?',
+  'How does staffing here compare to national benchmarks?',
+  'Show the clinical quality measures for this facility',
+  'Who owns this facility and what other facilities do they operate?',
+];

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -119,7 +119,7 @@ export default function HeftiResearch() {
         const subjectName =
           contextType === 'owner'
             ? toTitleCase(subject.cms_ownership_name)
-            : subject.provider_name;
+            : toTitleCase(subject.provider_name);
         // Normalizes the differing facility/owner rating fields into context
         // charts (KPI grid + bar). See lib/contextChart.
         const contextCharts = buildContextCharts({
@@ -127,7 +127,7 @@ export default function HeftiResearch() {
           subject,
           national,
           subjectName,
-        });
+        }).slice(1, 2);
         if (contextCharts.length) {
           contextChartCountRef.current = contextCharts.length;
           setCharts((prev) => (prev.length ? prev : contextCharts));
@@ -373,7 +373,7 @@ export default function HeftiResearch() {
 
       <div className="grid h-[calc(100vh-140px)] grid-cols-1 bg-white lg:grid-cols-2">
         {/**Left-Panel Text and Input */}
-        <section className="bg-background-secondary flex min-h-0 flex-col">
+        <section className="bg-background-tertiary flex min-h-0 flex-col">
           <div className="ml-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
             {hasStarted ? (
               <>
@@ -475,7 +475,7 @@ export default function HeftiResearch() {
         {/* Right panel — chart output */}
         <section
           aria-label="Generated charts"
-          className="flex min-h-0 flex-col bg-white"
+          className="bg-background-secondary flex min-h-0 flex-col"
         >
           {/* aria-live announces newly streamed charts to screen readers, since
               they appear without any focus or navigation change. */}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -263,7 +263,7 @@ export default function HeftiResearch() {
       const topOffset = messageRect.top - containerRect.top;
 
       container.scrollTo({
-        top: container.scrollTop + topOffset,
+        top: container.scrollTop + topOffset - 24,
         behavior: 'auto',
       });
     });

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
@@ -24,9 +24,22 @@ const API_BASE_URL =
  *   Fetch ReadableStream API and renders them with react-markdown.
  * - Keeps a rolling history of the last 20 messages to support multi-turn
  *   conversation without unbounded context growth.
- * - Uses `flushSync` + `requestAnimationFrame` to scroll the latest user
- *   bubble to the top of the viewport immediately after send, before the
- *   assistant has produced any output.
+ *
+ * Scroll behavior — both panels pin the newest content to the top of their
+ * viewport so each turn starts from the top, but they do it differently because
+ * of *when* their anchor element exists:
+ *
+ * - Left (chat): the anchor is the user's message, which exists the instant they
+ *   hit send. So we pin it SYNCHRONOUSLY inside submitPrompt — `flushSync` commits
+ *   the message, then a single `requestAnimationFrame` scrolls it to the top.
+ *   Room to scroll is made by giving the latest assistant bubble a min-height
+ *   (`assistantMinHeight`) equal to ~one viewport.
+ * - Right (charts): the anchor is the turn's first chart, which does NOT exist at
+ *   send time — charts stream in asynchronously over the response. So we pin
+ *   REACTIVELY in a `useEffect` keyed on `charts`, scrolling once that first chart
+ *   arrives. Room to scroll is made by a trailing spacer (`chartsSpacerHeight`)
+ *   sized to the right panel's full height, which also survives the brief window
+ *   before Recharts has measured the incoming chart.
  *
  * Route params:
  *  - slug: string — the owner or facility slug, forwarded to the API for context.
@@ -46,14 +59,24 @@ export default function HeftiResearch() {
   const [messages, setMessages] = useState([]);
   const [charts, setCharts] = useState([]);
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
+  const [chartsSpacerHeight, setChartsSpacerHeight] = useState(0);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
+  const chartsPanelRef = useRef(null);
+  // Mirrors lastUserMsgRef on the left: the first chart produced by the current
+  // turn, which we pin to the top of the panel once it arrives.
+  const turnFirstChartRef = useRef(null);
+  // The index the current turn's first chart will occupy, snapshotted at submit
+  // (before any new charts have streamed in).
+  const turnStartIndexRef = useRef(null);
   const hasStarted = messages.length > 0;
 
-  // Tracks the height of the scroll container so we can give the incoming assistant
-  // message bubble enough min-height to fill the remaining viewport. This ensures
-  // there's always enough scroll depth to push the user message to the top of the
-  // view when a new message is sent, even before the assistant has streamed any content.
+  // Left side (chat): tracks the height of the scroll container so we can give the
+  // incoming assistant message bubble enough min-height to fill the remaining
+  // viewport. This ensures there's always enough scroll depth to push the user
+  // message to the top of the view when a new message is sent, even before the
+  // assistant has streamed any content. (The right panel's equivalent spacer
+  // measurement is the next effect below.)
   useLayoutEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
@@ -69,6 +92,52 @@ export default function HeftiResearch() {
 
     return () => resizeObserver.disconnect();
   }, [hasStarted]);
+
+  // Right-panel equivalent of the spacer measurement above. We track the chart
+  // panel's own full height (it's taller than the left container, which excludes
+  // the composer) and use it as a trailing spacer. Sizing the spacer to a full
+  // viewport guarantees there's enough scroll depth to pin a new turn's first
+  // chart to the top even during the brief window before Recharts has measured
+  // and laid out the chart (when it still reports near-zero height).
+  useLayoutEffect(() => {
+    const panel = chartsPanelRef.current;
+    if (!panel) return;
+
+    function updateChartsSpacerHeight() {
+      setChartsSpacerHeight(panel.clientHeight);
+    }
+
+    updateChartsSpacerHeight();
+
+    const resizeObserver = new ResizeObserver(updateChartsSpacerHeight);
+    resizeObserver.observe(panel);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  // Right-panel counterpart to the left side's scroll-to-top (see the scroll block
+  // in submitPrompt). Unlike the left — which pins synchronously at send time
+  // because the user message already exists — charts stream in asynchronously, so
+  // we must pin REACTIVELY here: this effect fires when `charts` changes and acts
+  // only when the turn's first chart has just arrived (length === startIdx + 1),
+  // scrolling it to the top. The trailing spacer in the render guarantees enough
+  // scroll depth below it, exactly how assistantMinHeight makes room on the left.
+  useEffect(() => {
+    const panel = chartsPanelRef.current;
+    const startIdx = turnStartIndexRef.current;
+    if (!panel || startIdx === null || charts.length !== startIdx + 1) return;
+
+    requestAnimationFrame(() => {
+      const chart = turnFirstChartRef.current;
+      if (!panel || !chart) return;
+
+      const panelRect = panel.getBoundingClientRect();
+      const chartRect = chart.getBoundingClientRect();
+      const topOffset = chartRect.top - panelRect.top;
+
+      panel.scrollTo({ top: panel.scrollTop + topOffset, behavior: 'smooth' });
+    });
+  }, [charts]);
 
   async function submitPrompt() {
     const trimmedPrompt = prompt.trim();
@@ -89,7 +158,7 @@ export default function HeftiResearch() {
       isError: false,
     };
 
-    setCharts([]);
+    turnStartIndexRef.current = charts.length;
 
     // flushSync forces React to commit the new messages to the DOM synchronously
     // before we proceed. Without this, the requestAnimationFrame below would run
@@ -104,6 +173,11 @@ export default function HeftiResearch() {
     // sits at the top of the viewport. We use requestAnimationFrame to wait one
     // paint cycle, ensuring layout is complete and getBoundingClientRect() returns
     // accurate values before we calculate the scroll offset.
+    //
+    // This is the SYNCHRONOUS counterpart to the right panel's pin-to-top. We can
+    // do it inline here because the anchor (the user message) already exists after
+    // the flushSync above. The right panel can't — its charts arrive later over
+    // the stream — so it pins reactively in the `charts` useEffect instead.
     requestAnimationFrame(() => {
       const container = messagesContainerRef.current;
       const lastUserMessage = lastUserMsgRef.current;
@@ -147,6 +221,10 @@ export default function HeftiResearch() {
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
+      // DEBUG-ONLY: finalText/finalCharts exist solely to feed the debug log at
+      // the end of the stream loop. The UI is driven by setMessages/setCharts,
+      // not these. Remove these two declarations and their accumulation lines
+      // below when the debug console.log is removed.
       let finalText = '';
       const finalCharts = [];
       let lineBuffer = '';
@@ -196,6 +274,8 @@ export default function HeftiResearch() {
         }
       }
 
+      // DEBUG-ONLY: remove before production. Removing this also makes finalText
+      // and finalCharts (declared above) dead code — delete them together.
       console.log('[researcher] final response:', { text: finalText, charts: finalCharts });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
@@ -291,10 +371,25 @@ export default function HeftiResearch() {
 
         {/* Right panel — chart output */}
         <section className="flex min-h-0 flex-col bg-white">
-          <div className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
+          <div ref={chartsPanelRef} className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
             {charts.map((chart, i) => (
-              <ResearchChart key={i} chart={chart} />
+              <div
+                key={i}
+                ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+              >
+                <ResearchChart chart={chart} />
+              </div>
             ))}
+            {/* Trailing spacer — guarantees enough scroll depth to pin a new
+                turn's first chart to the top, mirroring assistantMinHeight on
+                the left panel. Sized to the panel's full height so the pin works
+                even before Recharts has laid out the incoming chart. */}
+            {charts.length > 0 && (
+              <div
+                aria-hidden="true"
+                style={{ minHeight: `${chartsSpacerHeight}px` }}
+              />
+            )}
           </div>
         </section>
       </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
-import { buildContextChart } from '../lib/contextChart';
+import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 
 const API_BASE_URL =
@@ -36,6 +36,8 @@ const DATA_API_BASE_URL =
  *   Fetch ReadableStream API and renders them with react-markdown.
  * - Keeps a rolling history of the last 20 messages to support multi-turn
  *   conversation without unbounded context growth.
+ * - Seeds the right panel with on-load context charts (KPI + comparison bar)
+ *   fetched on mount before the user sends any messages.
  *
  * Scroll behavior — both panels pin the newest content to the top of their
  * viewport so each turn starts from the top, but they do it differently because
@@ -82,6 +84,9 @@ export default function HeftiResearch() {
   // The index the current turn's first chart will occupy, snapshotted at submit
   // (before any new charts have streamed in).
   const turnStartIndexRef = useRef(null);
+  // Count of on-load context charts — used to position the session-start divider
+  // between the baseline charts and the first AI-generated chart.
+  const contextChartCountRef = useRef(0);
   const hasStarted = messages.length > 0;
 
   // On-load context chart: fetch the subject + national ratings from the
@@ -114,15 +119,18 @@ export default function HeftiResearch() {
           contextType === 'owner'
             ? toTitleCase(subject.cms_ownership_name)
             : subject.provider_name;
-        // Normalizes the differing facility/owner rating fields into a single
-        // `comparison_bar` chart (subject vs. national). See lib/contextChart.
-        const chart = buildContextChart({
+        // Normalizes the differing facility/owner rating fields into context
+        // charts (KPI grid + bar). See lib/contextChart.
+        const contextCharts = buildContextCharts({
           contextType,
           subject,
           national,
           subjectName,
         });
-        if (chart) setCharts((prev) => (prev.length ? prev : [chart]));
+        if (contextCharts.length) {
+          contextChartCountRef.current = contextCharts.length;
+          setCharts((prev) => (prev.length ? prev : contextCharts));
+        }
       })
       // The on-load chart is non-critical; leave the panel empty on failure.
       .catch(() => {});
@@ -452,13 +460,26 @@ export default function HeftiResearch() {
             aria-live="polite"
             className="mr-auto flex h-full w-full max-w-[600px] flex-col space-y-4 overflow-y-auto p-6"
           >
+            {!hasStarted && charts.length > 0 && (
+              <p className="text-paragraph-sm text-content-secondary pb-2">
+                More visualizations will appear here as you explore.
+              </p>
+            )}
             {charts.map((chart, i) => (
-              <div
-                key={i}
-                ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
-              >
-                <ResearchChart chart={chart} />
-              </div>
+              <React.Fragment key={i}>
+                <div
+                  ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+                >
+                  <ResearchChart chart={chart} />
+                </div>
+                {hasStarted && i === contextChartCountRef.current - 1 && (
+                  <div className="flex items-center gap-3 py-2">
+                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                    <span className="text-paragraph-sm text-content-secondary shrink-0">Session start</span>
+                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                  </div>
+                )}
+              </React.Fragment>
             ))}
             {/* Trailing spacer — guarantees enough scroll depth to pin a new
                 turn's first chart to the top, mirroring assistantMinHeight on

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -371,7 +371,7 @@ export default function HeftiResearch() {
         Hefti Researcher
       </Heading>
 
-      <div className="grid h-[calc(100vh-140px)] grid-cols-1 bg-white lg:grid-cols-2">
+      <div className="grid h-[calc(100vh-140px)] grid-cols-1 bg-core-white lg:grid-cols-2">
         {/**Left-Panel Text and Input */}
         <section className="bg-background-tertiary flex min-h-0 flex-col">
           <div className="ml-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
@@ -454,7 +454,7 @@ export default function HeftiResearch() {
                         <button
                           key={p}
                           onClick={() => submitPrompt(p)}
-                          className="text-paragraph-sm text-core-black border-border-primary bg-core-white cursor-pointer rounded-xl border px-4 py-3 text-left transition-colors hover:bg-zinc-50"
+                          className="text-paragraph-sm text-core-black border-border-primary bg-core-white cursor-pointer rounded-xl border px-4 py-3 text-left transition-colors hover:bg-background-tertiary"
                         >
                           {p}
                         </button>
@@ -502,14 +502,14 @@ export default function HeftiResearch() {
                   <div className="flex items-center gap-3 py-2">
                     <div
                       aria-hidden="true"
-                      className="h-px flex-1 bg-zinc-200"
+                      className="h-px flex-1 bg-border-primary"
                     />
                     <span className="text-paragraph-sm text-content-secondary shrink-0">
                       Session start
                     </span>
                     <div
                       aria-hidden="true"
-                      className="h-px flex-1 bg-zinc-200"
+                      className="h-px flex-1 bg-border-primary"
                     />
                   </div>
                 )}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -127,9 +127,9 @@ export default function HeftiResearch() {
     const startIdx = turnStartIndexRef.current;
     if (!panel || startIdx === null || charts.length !== startIdx + 1) return;
 
-    requestAnimationFrame(() => {
+    const frameId = requestAnimationFrame(() => {
       const chart = turnFirstChartRef.current;
-      if (!panel || !chart) return;
+      if (!chart) return;
 
       const panelRect = panel.getBoundingClientRect();
       const chartRect = chart.getBoundingClientRect();
@@ -137,6 +137,8 @@ export default function HeftiResearch() {
 
       panel.scrollTo({ top: panel.scrollTop + topOffset, behavior: 'smooth' });
     });
+
+    return () => cancelAnimationFrame(frameId);
   }, [charts]);
 
   async function submitPrompt() {
@@ -370,8 +372,17 @@ export default function HeftiResearch() {
         </section>
 
         {/* Right panel — chart output */}
-        <section className="flex min-h-0 flex-col bg-white">
-          <div ref={chartsPanelRef} className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4">
+        <section
+          aria-label="Generated charts"
+          className="flex min-h-0 flex-col bg-white"
+        >
+          {/* aria-live announces newly streamed charts to screen readers, since
+              they appear without any focus or navigation change. */}
+          <div
+            ref={chartsPanelRef}
+            aria-live="polite"
+            className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4"
+          >
             {charts.map((chart, i) => (
               <div
                 key={i}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -13,6 +13,7 @@ import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
+import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
@@ -104,13 +105,13 @@ export default function HeftiResearch() {
         : `facilities/${slug}`;
 
     Promise.all([
-      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((r) =>
-        r.ok ? r.json() : null,
+      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((response) =>
+        response.ok ? response.json() : null,
       ),
       // National bars are best-effort — resolve to null on failure so the chart
       // can still render the subject's own ratings.
       fetch(`${DATA_API_BASE_URL}/national`)
-        .then((r) => (r.ok ? r.json() : null))
+        .then((response) => (response.ok ? response.json() : null))
         .catch(() => null),
     ])
       .then(([subject, national]) => {
@@ -210,8 +211,10 @@ export default function HeftiResearch() {
     return () => cancelAnimationFrame(frameId);
   }, [charts]);
 
-  async function submitPrompt() {
-    const trimmedPrompt = prompt.trim();
+  async function submitPrompt(override) {
+    const trimmedPrompt = (
+      typeof override === 'string' ? override : prompt
+    ).trim();
     if (!trimmedPrompt) return;
 
     // Snapshot history before touching state
@@ -429,14 +432,35 @@ export default function HeftiResearch() {
                 />
               </>
             ) : (
-              <div className="flex flex-1 flex-col items-center justify-center gap-6">
-                <div className="text-center">
-                  <Heading level={2} className="text-heading-lg mb-2">
+              <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex-1 overflow-y-auto px-6 py-8">
+                  <Heading level={2} className="text-heading-lg mb-1">
                     Hefti Researcher
                   </Heading>
-                  <p className="text-paragraph-lg text-content-secondary">
-                    Ask a question about facilities, owners, or quality data.
+                  <p className="text-paragraph-base text-content-secondary mb-6">
+                    {contextType === 'owner'
+                      ? "Ask a question about this owner's facilities, quality, staffing, or financials."
+                      : "Ask a question about this facility's quality, staffing, deficiencies, or ownership."}
                   </p>
+                  <div className="hidden md:block">
+                    <p className="text-paragraph-sm text-content-secondary mb-3 font-medium">
+                      Try asking
+                    </p>
+                    <div className="flex flex-col items-start gap-2">
+                      {(contextType === 'owner'
+                        ? OWNER_PROMPTS
+                        : FACILITY_PROMPTS
+                      ).map((p) => (
+                        <button
+                          key={p}
+                          onClick={() => submitPrompt(p)}
+                          className="text-paragraph-sm text-core-black border-border-primary bg-core-white cursor-pointer rounded-xl border px-4 py-3 text-left transition-colors hover:bg-zinc-50"
+                        >
+                          {p}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
                 </div>
                 <ResearcherComposer
                   value={prompt}
@@ -468,15 +492,25 @@ export default function HeftiResearch() {
             {charts.map((chart, i) => (
               <React.Fragment key={i}>
                 <div
-                  ref={i === turnStartIndexRef.current ? turnFirstChartRef : null}
+                  ref={
+                    i === turnStartIndexRef.current ? turnFirstChartRef : null
+                  }
                 >
                   <ResearchChart chart={chart} />
                 </div>
                 {hasStarted && i === contextChartCountRef.current - 1 && (
                   <div className="flex items-center gap-3 py-2">
-                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
-                    <span className="text-paragraph-sm text-content-secondary shrink-0">Session start</span>
-                    <div aria-hidden="true" className="h-px flex-1 bg-zinc-200" />
+                    <div
+                      aria-hidden="true"
+                      className="h-px flex-1 bg-zinc-200"
+                    />
+                    <span className="text-paragraph-sm text-content-secondary shrink-0">
+                      Session start
+                    </span>
+                    <div
+                      aria-hidden="true"
+                      className="h-px flex-1 bg-zinc-200"
+                    />
                   </div>
                 )}
               </React.Fragment>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -127,7 +127,7 @@ export default function HeftiResearch() {
           subject,
           national,
           subjectName,
-        }).slice(1, 2);
+        });
         if (contextCharts.length) {
           contextChartCountRef.current = contextCharts.length;
           setCharts((prev) => (prev.length ? prev : contextCharts));

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -5,12 +5,24 @@ import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
 import ReactMarkdown from 'react-markdown';
 import { MdComponents } from '../lib/mdComponents';
-import { getResearchPages, getRankingsResearchPages } from '../lib/breadcrumbPages';
+import {
+  getResearchPages,
+  getRankingsResearchPages,
+} from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
 import ResearchChart from '../components/ui/molecule/ResearchChart';
+import { buildContextChart } from '../lib/contextChart';
+import { toTitleCase } from '../lib/toTitleCase';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
+  'http://hefti-data-api.ddev.site:3000/api';
+
+// The researcher stream lives behind VITE_RESEARCHER_FUNCTION_URL, but the
+// on-load context chart pulls subject + national data from the regular data API
+// (the same endpoints the profile pages use), which is a separate env var.
+const DATA_API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 /**
  * HeftiResearch
@@ -51,9 +63,10 @@ export default function HeftiResearch() {
   const contextType = pathname.includes('/owners/') ? 'owner' : 'facility';
 
   // Swaps in rankings breadcrumb trail when arriving via the rankings page.
-  const researchPages = state?.from === 'rankings'
-    ? getRankingsResearchPages(slug, contextType)
-    : getResearchPages(slug, contextType);
+  const researchPages =
+    state?.from === 'rankings'
+      ? getRankingsResearchPages(slug, contextType)
+      : getResearchPages(slug, contextType);
 
   const [prompt, setPrompt] = useState('');
   const [messages, setMessages] = useState([]);
@@ -70,6 +83,54 @@ export default function HeftiResearch() {
   // (before any new charts have streamed in).
   const turnStartIndexRef = useRef(null);
   const hasStarted = messages.length > 0;
+
+  // On-load context chart: fetch the subject + national ratings from the
+  // URL and seed a comparison chart into the right panel before the user sends
+  // anything. Fetching keeps it correct on reload/shared links.
+  // The `prev.length ? prev : [chart]` guard makes a late fetch a no-op once any
+  // chart exists, so it can't clobber streamed charts.
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+
+    const subjectPath =
+      contextType === 'owner'
+        ? `owners/${encodeURIComponent(slug)}`
+        : `facilities/${slug}`;
+
+    Promise.all([
+      fetch(`${DATA_API_BASE_URL}/${subjectPath}`).then((r) =>
+        r.ok ? r.json() : null,
+      ),
+      // National bars are best-effort — resolve to null on failure so the chart
+      // can still render the subject's own ratings.
+      fetch(`${DATA_API_BASE_URL}/national`)
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ])
+      .then(([subject, national]) => {
+        if (cancelled || !subject) return;
+        const subjectName =
+          contextType === 'owner'
+            ? toTitleCase(subject.cms_ownership_name)
+            : subject.provider_name;
+        // Normalizes the differing facility/owner rating fields into a single
+        // `comparison_bar` chart (subject vs. national). See lib/contextChart.
+        const chart = buildContextChart({
+          contextType,
+          subject,
+          national,
+          subjectName,
+        });
+        if (chart) setCharts((prev) => (prev.length ? prev : [chart]));
+      })
+      // The on-load chart is non-critical; leave the panel empty on failure.
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, contextType]);
 
   // Left side (chat): tracks the height of the scroll container so we can give the
   // incoming assistant message bubble enough min-height to fill the remaining
@@ -239,7 +300,9 @@ export default function HeftiResearch() {
         // Accumulate into a line buffer so SSE lines split across TCP chunks are
         // reassembled before parsing. Without this, large chart payloads cause
         // JSON.parse failures when the chunk boundary falls mid-line.
-        lineBuffer += decoder.decode(value ?? new Uint8Array(), { stream: !done });
+        lineBuffer += decoder.decode(value ?? new Uint8Array(), {
+          stream: !done,
+        });
 
         const lines = lineBuffer.split('\n');
         // Keep the last (potentially incomplete) segment in the buffer
@@ -248,7 +311,10 @@ export default function HeftiResearch() {
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
           const payload = line.slice(6);
-          if (payload === '[DONE]') { done = true; break; }
+          if (payload === '[DONE]') {
+            done = true;
+            break;
+          }
 
           const { text, error, chart } = JSON.parse(payload);
 
@@ -278,7 +344,10 @@ export default function HeftiResearch() {
 
       // DEBUG-ONLY: remove before production. Removing this also makes finalText
       // and finalCharts (declared above) dead code — delete them together.
-      console.log('[researcher] final response:', { text: finalText, charts: finalCharts });
+      console.log('[researcher] final response:', {
+        text: finalText,
+        charts: finalCharts,
+      });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
     }
@@ -381,7 +450,7 @@ export default function HeftiResearch() {
           <div
             ref={chartsPanelRef}
             aria-live="polite"
-            className="mr-auto flex h-full w-full max-w-[600px] flex-col overflow-y-auto p-6 space-y-4"
+            className="mr-auto flex h-full w-full max-w-[600px] flex-col space-y-4 overflow-y-auto p-6"
           >
             {charts.map((chart, i) => (
               <div


### PR DESCRIPTION
- Replaces all hardcoded zinc/hex values in ResearchChart.jsx with Hefti design tokens across all six chart views (BarView, ComparisonBarView, ScatterView, DistributionView, KpiRowView, TableView)
- Extracts Recharts-specific colors as named constants (CHART_GRID_COLOR, CHART_AXIS_COLOR, CHART_TICK_STYLE) with comments mapping them to their token equivalents — Recharts cannot consume CSS variables directly
- Updates chart palette to use home page accent colors (blue-400 subject series, violet-600 benchmark series) in place of the default rainbow; blue-600 reserved for link behavior
- Adds PropTypes to all components; adds file-level JSDoc
- Fixes facility names rendering in ALL CAPS in KPI chart titles (toTitleCase was missing on the facility branch)
- Token sweep on HeftiResearch.jsx: bg-core-white, bg-background-tertiary, bg-border-primary replacing raw zinc classes