### PR TITLE
Facility sort update

### DIFF
--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -9,8 +9,9 @@ import { CheckIcon } from '@heroicons/react/20/solid';
  * Reusable sort/filter control for browse pages.
  *
  * Variants:
- * - `sort`: sorts by name (A-Z / Z-A) by default; accepts custom sortOptions for field-based sorts
- * - `filter`: allows filtering by state
+ * - `sort`: Ascending / Descending; accepts custom sortOptions to override the defaults
+ * - `filter`: sort category picker (Name, Overall Rating, etc.); requires filterOptions prop
+ * - `state`: state picker; uses built-in 50-state list by default
  *
  * Behavior:
  * - Desktop renders a native single-select control

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -19,10 +19,10 @@ import { CheckIcon } from '@heroicons/react/20/solid';
 
 const OPTIONS = {
   sort: [
-    { label: 'Sort A to Z', value: 'asc' },
-    { label: 'Sort Z to A', value: 'desc' },
+    { label: 'Ascending', value: 'asc' },
+    { label: 'Descending', value: 'desc' },
   ],
-  filter: [
+  state: [
     { label: 'AL', value: 'AL' },
     { label: 'AK', value: 'AK' },
     { label: 'AZ', value: 'AZ' },
@@ -74,6 +74,7 @@ const OPTIONS = {
     { label: 'WI', value: 'WI' },
     { label: 'WY', value: 'WY' },
   ],
+  filter: [],
 };
 
 export default function SelectMenu({
@@ -92,7 +93,7 @@ export default function SelectMenu({
   const label = variant.charAt(0).toUpperCase() + variant.slice(1);
   const options =
     variant === 'sort' && sortOptions ? sortOptions :
-    variant === 'filter' && filterOptions ? filterOptions :
+    filterOptions ? filterOptions :
     OPTIONS[variant] || [];
 
   // Derive selected option from the value prop (set externally via URL params).
@@ -264,7 +265,7 @@ export default function SelectMenu({
 
 SelectMenu.propTypes = {
   onChange: PropTypes.func,
-  variant: PropTypes.oneOf(['sort', 'filter']),
+  variant: PropTypes.oneOf(['sort', 'filter', 'state']),
   onSortChange: PropTypes.func,
   onFilterChange: PropTypes.func,
   onStateChange: PropTypes.func,

--- a/src/components/ui/molecule/selectMenu.jsx
+++ b/src/components/ui/molecule/selectMenu.jsx
@@ -196,7 +196,7 @@ export default function SelectMenu({
           </div>
 
           <Heading id={headingId} className="text-label-lg mb-2 font-bold">
-            {label} By
+            {variant === 'state' ? label : `${label} By`}
           </Heading>
 
           <div className="flex-1 overflow-y-auto">

--- a/src/components/ui/organism/browseListView.jsx
+++ b/src/components/ui/organism/browseListView.jsx
@@ -25,6 +25,8 @@ export default function BrowseListView({
   onSearchChange,
   onSortChange,
   onStateChange,
+  onCategoryChange,
+  showStateFilter = true,
   suggestions,
   hasFetchedSuggestions,
   type,
@@ -34,6 +36,7 @@ export default function BrowseListView({
   onFilterChange,
   onSuggestionPick,
   sortValue,
+  filterValue,
   stateValue,
 }) {
   const searchHeadingId = useId();
@@ -73,14 +76,24 @@ export default function BrowseListView({
                 sortOptions={sortOptions}
                 value={sortValue}
               />
-              {/* onFilterChange replaces onStateChange when provided (rankings context only) */}
-              <SelectMenu
-                variant="filter"
-                onStateChange={onFilterChange ?? onStateChange}
-                accessibleLabel={filterAccessibleLabel ?? 'Filter by state'}
-                filterOptions={filterOptions}
-                value={stateValue}
-              />
+              {/* onFilterChange (rankings nav) takes priority, then onCategoryChange (facilities), then state */}
+              {(filterOptions?.length > 0 || onFilterChange) && (
+                <SelectMenu
+                  variant="filter"
+                  onStateChange={onFilterChange ?? onCategoryChange ?? onStateChange}
+                  accessibleLabel={filterAccessibleLabel ?? 'Filter by category'}
+                  filterOptions={filterOptions}
+                  value={onFilterChange ? stateValue : filterValue ?? stateValue}
+                />
+              )}
+              {showStateFilter && (
+                <SelectMenu
+                  variant="state"
+                  onStateChange={onStateChange}
+                  accessibleLabel="Filter by state"
+                  value={stateValue}
+                />
+              )}
             </div>
           </div>
         </div>
@@ -121,6 +134,7 @@ BrowseListView.propTypes = {
   hasFetchedSuggestions: PropTypes.bool,
   onSortChange: PropTypes.func,
   onStateChange: PropTypes.func,
+  onCategoryChange: PropTypes.func,
   type: PropTypes.string,
   sortOptions: PropTypes.array,
   filterOptions: PropTypes.array,
@@ -128,5 +142,6 @@ BrowseListView.propTypes = {
   onFilterChange: PropTypes.func,
   onSuggestionPick: PropTypes.func,
   sortValue: PropTypes.string,
+  filterValue: PropTypes.string,
   stateValue: PropTypes.string,
 };

--- a/src/components/ui/organism/browseListView.jsx
+++ b/src/components/ui/organism/browseListView.jsx
@@ -80,10 +80,16 @@ export default function BrowseListView({
               {(filterOptions?.length > 0 || onFilterChange) && (
                 <SelectMenu
                   variant="filter"
-                  onStateChange={onFilterChange ?? onCategoryChange ?? onStateChange}
-                  accessibleLabel={filterAccessibleLabel ?? 'Filter by category'}
+                  onStateChange={
+                    onFilterChange ?? onCategoryChange ?? onStateChange
+                  }
+                  accessibleLabel={
+                    filterAccessibleLabel ?? 'Filter by category'
+                  }
                   filterOptions={filterOptions}
-                  value={onFilterChange ? stateValue : filterValue ?? stateValue}
+                  value={
+                    onFilterChange ? stateValue : (filterValue ?? stateValue)
+                  }
                 />
               )}
               {showStateFilter && (
@@ -135,6 +141,7 @@ BrowseListView.propTypes = {
   onSortChange: PropTypes.func,
   onStateChange: PropTypes.func,
   onCategoryChange: PropTypes.func,
+  showStateFilter: PropTypes.bool,
   type: PropTypes.string,
   sortOptions: PropTypes.array,
   filterOptions: PropTypes.array,

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -42,6 +42,7 @@ BrowsePage.propTypes = {
   filterAccessibleLabel: PropTypes.string,
   onFilterChange: PropTypes.func,
   onSuggestionPick: PropTypes.func,
+  showStateFilter: PropTypes.bool,
 };
 
 export default function BrowsePage({
@@ -56,6 +57,7 @@ export default function BrowsePage({
   filterAccessibleLabel,
   onFilterChange,
   onSuggestionPick,
+  showStateFilter = true,
   defaultSort = 'asc',
 }) {
   // // --- URL Params ---
@@ -67,11 +69,8 @@ export default function BrowsePage({
   const state = searchParams.get('state') || '';
   const chain = searchParams.get('chain') || '';
 
-  // The compound value the sort SelectMenu should reflect (e.g. "overall_rating:desc" or "asc").
-  // Used to keep the control in sync when URL params arrive via navigation (e.g. from rankings).
-  const currentSortValue = sortBy
-    ? `${sortBy}:${searchParams.get('sort') || defaultSort}`
-    : searchParams.get('sort') || '';
+  const currentSortValue = searchParams.get('sort') || '';
+  const currentFilterValue = sortBy || '';
   // // --- UI State ---
   const [hasFetchedSuggestions, setHasFetchedSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState([]);
@@ -145,6 +144,24 @@ export default function BrowsePage({
     [setSearchParams],
   );
 
+  const handleCategoryChange = useCallback(
+    (val) => {
+      setSearchParams((prev) => {
+        const params = new URLSearchParams(prev);
+        params.set('page', 1);
+        if (!val || val === 'name') {
+          params.delete('sortBy');
+          params.set('sort', 'asc');
+        } else {
+          params.set('sortBy', val);
+          params.set('sort', 'desc');
+        }
+        return params;
+      });
+    },
+    [setSearchParams],
+  );
+
   return (
     <div className="min-h-screen bg-gray-100">
       <div aria-live="polite" className="sr-only">
@@ -157,34 +174,11 @@ export default function BrowsePage({
         search={search}
         onSearchChange={(val) => updateParam('search', val)}
         sortValue={currentSortValue}
+        filterValue={currentFilterValue}
         stateValue={state}
-        // Sort option values follow a "field:direction" encoding convention defined in
-        // FACILITY_SORT_OPTIONS (Facilities.jsx). Field-based sorts use compound values
-        // like "overall_rating:desc", which are split here into separate `sortBy` and
-        // `sort` URL params for the API. Plain "asc"/"desc" values indicate a name sort
-        // and pass through as `sort` only. Any new sort options added to a page that
-        // uses this handler must follow the same convention.
-        onSortChange={(val) => {
-          setSearchParams((prev) => {
-            const params = new URLSearchParams(prev);
-            params.set('page', 1);
-            if (!val) {
-              // Clear button: reset both sort params to defaults
-              params.delete('sort');
-              params.delete('sortBy');
-            } else if (val.includes(':')) {
-              // Compound value like "overall_rating:desc" — split into field + direction
-              const [field, dir] = val.split(':');
-              params.set('sortBy', field);
-              params.set('sort', dir);
-            } else {
-              // Plain direction value ("asc"/"desc") — name sort, clear sortBy
-              params.set('sort', val);
-              params.delete('sortBy');
-            }
-            return params;
-          });
-        }}
+        onSortChange={(val) => updateParam('sort', val)}
+        onCategoryChange={handleCategoryChange}
+        showStateFilter={showStateFilter}
         onStateChange={(val) => updateParam('state', val)}
         suggestions={suggestions}
         hasFetchedSuggestions={hasFetchedSuggestions}

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -16,34 +16,22 @@ import { ErrorBanner, NoResultsBanner } from '../atom/errorBanner.jsx';
  * Search placeholders
  * Routing behavior
  *
+ * Shared optional props:
+ * - filterOptions: options for the Filter dropdown. Facilities passes sort categories;
+ *   Rankings passes ranking type switcher. Omit to hide the Filter dropdown entirely (e.g. Owners).
+ * - sortOptions: custom sort labels/values passed to SelectMenu. Omit to use the default Ascending/Descending.
+ * - showStateFilter: set to false to hide the State dropdown. Defaults to true.
+ *
  * Rankings-only props (not used by Facilities or Owners):
  * - suggestionsEndpoint: overrides the default `${apiEndpoint}/suggestions` fetch URL.
  *   Used by Rankings to point individual-owners suggestions at /api/owners/suggestions.
  * - defaultSort: overrides the default sort direction ('asc'). Rankings defaults to 'desc'.
- * - sortOptions: custom sort labels/values passed to SelectMenu. Rankings uses Descending/Ascending.
- * - filterOptions: custom filter options passed to SelectMenu. Rankings uses ranking type switcher.
- * - filterAccessibleLabel: overrides the default "Filter by state" aria-label on the filter control.
- * - onFilterChange: when provided, replaces the default state-param filter behavior.
- *   Rankings uses this to navigate between ranking types instead of filtering by state.
+ * - filterAccessibleLabel: overrides the default "Filter by category" aria-label on the filter control.
+ * - onFilterChange: when provided, replaces the default category-param filter behavior.
+ *   Rankings uses this to navigate between ranking types instead of setting a sort category.
  * - onSuggestionPick: when provided, overrides SearchMenu's default profile-page navigation.
  *   Rankings uses this to route chains to a filtered facility list and owners to their profile.
  */
-
-BrowsePage.propTypes = {
-  apiEndpoint: PropTypes.string.isRequired,
-  suggestionsEndpoint: PropTypes.string,
-  title: PropTypes.string.isRequired,
-  searchPlaceholder: PropTypes.string,
-  renderList: PropTypes.func.isRequired,
-  type: PropTypes.oneOf(['facilities', 'owners', 'rankings']),
-  sortOptions: PropTypes.array,
-  defaultSort: PropTypes.oneOf(['asc', 'desc']),
-  filterOptions: PropTypes.array,
-  filterAccessibleLabel: PropTypes.string,
-  onFilterChange: PropTypes.func,
-  onSuggestionPick: PropTypes.func,
-  showStateFilter: PropTypes.bool,
-};
 
 export default function BrowsePage({
   apiEndpoint,
@@ -60,7 +48,7 @@ export default function BrowsePage({
   showStateFilter = true,
   defaultSort = 'asc',
 }) {
-  // // --- URL Params ---
+  // --- URL Params ---
   const [searchParams, setSearchParams] = useSearchParams();
   const page = parseInt(searchParams.get('page')) || 1;
   const search = searchParams.get('search') || '';
@@ -71,7 +59,7 @@ export default function BrowsePage({
 
   const currentSortValue = searchParams.get('sort') || '';
   const currentFilterValue = sortBy || '';
-  // // --- UI State ---
+  // --- UI State ---
   const [hasFetchedSuggestions, setHasFetchedSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState([]);
   const [data, setData] = useState([]);
@@ -212,3 +200,19 @@ export default function BrowsePage({
     </div>
   );
 }
+
+BrowsePage.propTypes = {
+  apiEndpoint: PropTypes.string.isRequired,
+  suggestionsEndpoint: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  searchPlaceholder: PropTypes.string,
+  renderList: PropTypes.func.isRequired,
+  type: PropTypes.oneOf(['facilities', 'owners', 'rankings']),
+  sortOptions: PropTypes.array,
+  defaultSort: PropTypes.oneOf(['asc', 'desc']),
+  filterOptions: PropTypes.array,
+  filterAccessibleLabel: PropTypes.string,
+  onFilterChange: PropTypes.func,
+  onSuggestionPick: PropTypes.func,
+  showStateFilter: PropTypes.bool,
+};

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -31,23 +31,12 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 
-/**
- * Sort options for the facilities browse page.
- * Rating fields use a compound "field:direction" value so browsePage can split
- * them into separate `sortBy` and `sort` URL params for the API.
- * Plain "asc"/"desc" values fall back to the default name-based sort.
- */
-const FACILITY_SORT_OPTIONS = [
-  { label: 'Name (A–Z)', value: 'asc' },
-  { label: 'Name (Z–A)', value: 'desc' },
-  { label: 'Overall Rating (High–Low)', value: 'overall_rating:desc' },
-  { label: 'Overall Rating (Low–High)', value: 'overall_rating:asc' },
-  { label: 'Staffing Rating (High–Low)', value: 'staffing_rating:desc' },
-  { label: 'Staffing Rating (Low–High)', value: 'staffing_rating:asc' },
-  { label: 'Health Inspection (High–Low)', value: 'health_inspection_rating:desc' },
-  { label: 'Health Inspection (Low–High)', value: 'health_inspection_rating:asc' },
-  { label: 'Financial (High–Low)', value: 'operating_margin:desc' },
-  { label: 'Financial (Low–High)', value: 'operating_margin:asc' },
+const FACILITY_FILTER_OPTIONS = [
+  { label: 'Name', value: 'name' },
+  { label: 'Overall Rating', value: 'overall_rating' },
+  { label: 'Staffing Rating', value: 'staffing_rating' },
+  { label: 'Health Inspection', value: 'health_inspection_rating' },
+  { label: 'Financial', value: 'operating_margin' },
 ];
 
 function Facilities() {
@@ -75,7 +64,7 @@ function Facilities() {
         title="Nursing Homes"
         searchPlaceholder="Nursing home name..."
         type="facilities"
-        sortOptions={FACILITY_SORT_OPTIONS}
+        filterOptions={FACILITY_FILTER_OPTIONS}
         renderList={(items) => (
           <>
             {chain && (

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import ListContainer, {
   ListContainerSeparate,
 } from '../components/ui/organism/ListContainer';
-import { BrowseNursingHomes, BrowseNursingHomesRatings } from '../components/ui/molecule/listContainerContent';
+import {
+  BrowseNursingHomes,
+  BrowseNursingHomesRatings,
+} from '../components/ui/molecule/listContainerContent';
 import BrowsePage from '../components/ui/organism/browsePage';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import {
@@ -23,7 +26,7 @@ import { toTitleCase } from '../lib/toTitleCase';
  * - title: Page title
  * - searchPlaceholder: Input placeholder text
  * - type: Entity type for routing (facilities)
- * - sortOptions: Facilities-specific sort options (see FACILITY_SORT_OPTIONS)
+ * - filterOptions: Sort category options (Name, Overall Rating, etc.)
  * - renderList: Function rendering the list of facilities
  */
 
@@ -31,6 +34,7 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
 
+//We include the filter options here because this is specific to facility context. Facility, owner, and ranking browses share the same internal components, thus these options need to be passed into BrowsePage as contextual props
 const FACILITY_FILTER_OPTIONS = [
   { label: 'Name', value: 'name' },
   { label: 'Overall Rating', value: 'overall_rating' },
@@ -48,12 +52,18 @@ function Facilities() {
     state?.from === 'rankings' ? rankingsFacilityListPages : facilityListPages;
 
   // Pass linkState through to whichever card is rendered so the breadcrumb trail is correct.
-  const linkState = state?.from === 'rankings' ? { from: 'rankings' } : undefined;
+  const linkState =
+    state?.from === 'rankings' ? { from: 'rankings' } : undefined;
 
-  // When a field-based sort is active, show the ratings card with that metric highlighted.
-  // Otherwise fall back to the standard ownership card.
+  // When a field-based sort is active, show the ratings card with that metric highlighted. Otherwise fall back to the standard ownership card.
   const CardComponent = sortBy
-    ? (props) => <BrowseNursingHomesRatings {...props} activeMetric={sortBy} linkState={linkState} />
+    ? (props) => (
+        <BrowseNursingHomesRatings
+          {...props}
+          activeMetric={sortBy}
+          linkState={linkState}
+        />
+      )
     : (props) => <BrowseNursingHomes {...props} linkState={linkState} />;
 
   return (

--- a/src/pages/Rankings.jsx
+++ b/src/pages/Rankings.jsx
@@ -71,6 +71,7 @@ export default function Rankings() {
         sortOptions={RANKINGS_SORT_OPTIONS}
         filterOptions={RANKINGS_FILTER_OPTIONS}
         filterAccessibleLabel="Filter by ranking type"
+        showStateFilter={false}
         onFilterChange={(val) => val && navigate(`/rankings/${val}`)}
         onSuggestionPick={(suggestion) => {
           if (type === 'chains') navigate(`/facilities?chain=${suggestion.slug}`, { state: { from: 'rankings' } });


### PR DESCRIPTION
- Splits the old 10-item sort dropdown into three focused controls: Sort (Ascending/Descending), Filter (sort category: Name, Overall Rating, Staffing Rating, Health Inspection, Financial), and State (dedicated dropdown)
- Selecting a rating category auto-defaults to Descending (highest first); selecting Name defaults to Ascending
- Filter dropdown is hidden on Owners (no applicable categories) and State dropdown is hidden on Rankings (showStateFilter={false})
- Removes compound "field:direction" sort encoding from FACILITY_SORT_OPTIONS — field and direction are now independent URL params (sortBy + sort)
- Moves state list out of OPTIONS.filter into its own OPTIONS.state in SelectMenu; updates default sort labels to Ascending/Descending across all pages
- Cleans up stale JSDoc and PropTypes across all five touched files