### PR TITLE
Def pen tab(MERGE FIRST THEN #74)

### DIFF
--- a/src/components/ui/molecule/listContainerContent.jsx
+++ b/src/components/ui/molecule/listContainerContent.jsx
@@ -8,7 +8,6 @@ import { Divider } from '../atom/divider';
 import { toTitleCase } from '../../../lib/toTitleCase';
 import {
   badgeConfig,
-  getBadgeColorAboveBelow,
   getCmprColor,
 } from '../../../lib/getBadgeColor';
 import { ownerRoleMap } from '../../../lib/ownerRoleHelper';
@@ -963,49 +962,6 @@ StaffingCardShort.propTypes = {
   variant: PropTypes.oneOf(['desktop', 'mobile']),
 };
 
-/**
- * Compact staffing metric card used in the Staffing tab grid.
- *
- * Expected item shape:
- * - stat: primary staffing value
- * - title, description: card heading and explanatory copy
- * - rating: optional comparison badge label
- * - detail: supporting benchmark text shown at the bottom
- *
- * These items are typically built by the staffing metric helpers in src/lib/staffingMetrics.js.
- */
-export function StaffingStatCard({ item }) {
-  return (
-    <div className="border-border-primary h-full rounded-xl border bg-white px-4 py-4 shadow-sm">
-      <div className="flex items-start gap-2">
-        <div className="text-core-black text-heading-lg leading-none">
-          {item.stat}
-        </div>
-        {item.rating ? (
-          <Badge
-            color={getBadgeColorAboveBelow(item.rating)}
-            className="text-label-xs mt-1 leading-none"
-          >
-            {item.rating}
-          </Badge>
-        ) : null}
-      </div>
-      <div className="text-core-black text-label-lg mt-3">{item.title}</div>
-      <p className="text-content-secondary text-paragraph-base mt-1">
-        {item.description}
-      </p>
-      {item.detail ? (
-        <div className="text-content-secondary text-paragraph-base mt-6">
-          {item.detail}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-StaffingStatCard.propTypes = {
-  item: PropTypes.object.isRequired,
-};
 
 //This componenet is specifically designed to show the ("Li") shared facilities of the hub owner in the Network Graph Module side panel.
 export function NetworkSidePanelList({ item, onSelectNode, variant }) {

--- a/src/components/ui/molecule/statsCard.jsx
+++ b/src/components/ui/molecule/statsCard.jsx
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
  *        description: 'Total deficiencies found in the past year',
  *        detail1: 'Texas average: 10.3', detail2: 'National average: 11.1' }
  *    ];
- *    <StatsCard stats={data} variant="card" />
+ *    <StatsCard stats={data} variant="card" cols={2} />
  */
 
 const cardColsClass = {

--- a/src/components/ui/molecule/statsCard.jsx
+++ b/src/components/ui/molecule/statsCard.jsx
@@ -5,10 +5,19 @@ import PropTypes from 'prop-types';
 
 /**
  * This component is built with Application Ui Stats/Simple and Stats/With Shared Border.
- * The styles are applied to the components styling via the variant prop
+ * The styles are applied to the components styling via the variant prop.
+ *
+ * Each item in the stats array supports:
+ *   { key, stat, rating, isCurrency, description, detail1, detail2 }
+ * detail1 and detail2 render as benchmark lines below the description (e.g. state/national averages).
  *
  * Example:
- *    StatsCard stats={data} variant="panel"
+ *    const data = [
+ *      { key: 'Total Deficiencies', stat: 12, rating: 'Above Average', isCurrency: false,
+ *        description: 'Total deficiencies found in the past year',
+ *        detail1: 'Texas average: 10.3', detail2: 'National average: 11.1' }
+ *    ];
+ *    <StatsCard stats={data} variant="card" />
  */
 
 const variants = {

--- a/src/components/ui/molecule/statsCard.jsx
+++ b/src/components/ui/molecule/statsCard.jsx
@@ -7,36 +7,23 @@ import PropTypes from 'prop-types';
  * This component is built with Application Ui Stats/Simple and Stats/With Shared Border.
  * The styles are applied to the components styling via the variant prop.
  *
- * Each item in the stats array supports:
+ * card variant — single-item renderer, used as ListContent with ListContainer:
  *   { key, stat, rating, isCurrency, description, detail1, detail2 }
- * detail1 and detail2 render as benchmark lines below the description (e.g. state/national averages).
  *
- * Example:
- *    const data = [
- *      { key: 'Total Deficiencies', stat: 12, rating: 'Above Average', isCurrency: false,
- *        description: 'Total deficiencies found in the past year',
- *        detail1: 'Texas average: 10.3', detail2: 'National average: 11.1' }
- *    ];
- *    <StatsCard stats={data} variant="card" cols={2} />
+ * panel variant — array renderer, used standalone:
+ *   stats: [{ key, stat, rating, isCurrency, description, detail1, detail2 }]
+ *
+ * Example (card as ListContent):
+ *   <ListContainer items={data} LayoutSelector={ListContainerGrid} ListContent={StatsCard} layoutProps={{ cols: 2 }} />
+ *
+ * Example (panel standalone):
+ *   <StatsCard stats={data} variant="panel" />
  */
 
-const cardColsClass = {
-  1: 'sm:grid-cols-1',
-  2: 'sm:grid-cols-2',
-  3: 'sm:grid-cols-3',
-};
-
-const variants = {
-  card: {
-    wrapper: (cols) =>
-      `mt-5 grid grid-cols-1 gap-5 ${cardColsClass[cols] ?? 'sm:grid-cols-2'}`,
-    item: 'border-border-primary text-label-lg overflow-hidden rounded-lg border bg-white px-4 pt-5 pb-16 shadow-sm',
-  },
-  panel: {
-    wrapper:
-      'mt-5 grid grid-cols-1 divide-y divide-gray-200 overflow-hidden bg-white md:grid-cols-3 md:divide-x md:divide-y-0',
-    item: 'px-4 py-5 sm:p-6',
-  },
+const panelVariant = {
+  wrapper:
+    'mt-5 grid grid-cols-1 divide-y divide-gray-200 overflow-hidden bg-white md:grid-cols-3 md:divide-x md:divide-y-0',
+  item: 'px-4 py-5 sm:p-6',
 };
 
 function formatValue(value, isCurrency = false) {
@@ -53,52 +40,79 @@ function formatValue(value, isCurrency = false) {
     : number.toLocaleString();
 }
 
-function normalizeKey(str) {
-  return str
-    .toLowerCase()
-    .replace(/[^a-zA-Z0-9 ]/g, '')
-    .replace(/\s+(.)/g, (_, chr) => chr.toUpperCase());
+function StatCardItem({ item }) {
+  return (
+    <div className="border-border-primary h-full overflow-hidden rounded-lg border bg-white px-4 pt-5 pb-16 shadow-sm">
+      <p className="text-label-lg text-core-black">{item.key}</p>
+      <div className="flex flex-row gap-3 py-4">
+        <p className="text-heading-lg text-core-black leading-none">
+          {formatValue(item.stat, item.isCurrency)}
+        </p>
+        {item.rating && (
+          <div className="flex items-center">
+            <Badge
+              color={getBadgeColorAboveBelow(item.rating)}
+              className="text-label-xs leading-none"
+            >
+              {item.rating}
+            </Badge>
+          </div>
+        )}
+      </div>
+      <p className="text-paragraph-base text-content-secondary">{item.description}</p>
+      {(item.detail1 || item.detail2) && (
+        <div className="text-paragraph-base text-content-secondary mt-3 flex flex-col gap-0.5">
+          {item.detail1 && <span>{item.detail1}</span>}
+          {item.detail2 && <span>{item.detail2}</span>}
+        </div>
+      )}
+    </div>
+  );
 }
 
-//StatCardLayout handles all the styling
-function StatCardLayout({ stats, variant = 'panel', cols = 2 }) {
-  const styles = variants[variant];
-  const wrapperClass =
-    typeof styles.wrapper === 'function' ? styles.wrapper(cols) : styles.wrapper;
+StatCardItem.propTypes = {
+  item: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    stat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    rating: PropTypes.string,
+    isCurrency: PropTypes.bool,
+    description: PropTypes.string,
+    detail1: PropTypes.string,
+    detail2: PropTypes.string,
+  }).isRequired,
+};
+
+function StatCardLayout({ stats }) {
   return (
     <div>
-      <dl className={wrapperClass} aria-label="Statistics summary">
-        {stats.map((item, i) => {
-          return (
-            <div key={item.key + i} className={styles.item}>
-              <dt className="text-label-lg text-core-black flex items-center truncate">
-                {item.key}
-              </dt>
-              <div className="flex flex-row gap-3 py-4">
-                <dd className="text-heading-lg text-core-black leading-none">
-                  {formatValue(item.stat, item.isCurrency)}
-                </dd>
-                <div className="flex items-center">
-                  <Badge
-                    color={getBadgeColorAboveBelow(item.rating)}
-                    className="text-label-xs leading-none"
-                  >
-                    {item.rating}
-                  </Badge>
-                </div>
+      <dl className={panelVariant.wrapper} aria-label="Statistics summary">
+        {stats.map((item, i) => (
+          <div key={item.key + i} className={panelVariant.item}>
+            <dt className="text-label-lg text-core-black flex items-center truncate">
+              {item.key}
+            </dt>
+            <div className="flex flex-row gap-3 py-4">
+              <dd className="text-heading-lg text-core-black leading-none">
+                {formatValue(item.stat, item.isCurrency)}
+              </dd>
+              <div className="flex items-center">
+                <Badge
+                  color={getBadgeColorAboveBelow(item.rating)}
+                  className="text-label-xs leading-none"
+                >
+                  {item.rating}
+                </Badge>
               </div>
-              <div className="text-paragraph-base text-content-secondary">
-                {item.description}
-              </div>
-              {(item.detail1 || item.detail2) && (
-                <div className="text-paragraph-base text-content-secondary mt-3 flex flex-col gap-0.5">
-                  {item.detail1 && <span>{item.detail1}</span>}
-                  {item.detail2 && <span>{item.detail2}</span>}
-                </div>
-              )}
             </div>
-          );
-        })}
+            <div className="text-paragraph-base text-content-secondary">{item.description}</div>
+            {(item.detail1 || item.detail2) && (
+              <div className="text-paragraph-base text-content-secondary mt-3 flex flex-col gap-0.5">
+                {item.detail1 && <span>{item.detail1}</span>}
+                {item.detail2 && <span>{item.detail2}</span>}
+              </div>
+            )}
+          </div>
+        ))}
       </dl>
     </div>
   );
@@ -116,17 +130,17 @@ StatCardLayout.propTypes = {
       detail2: PropTypes.string,
     }),
   ).isRequired,
-  variant: PropTypes.oneOf(['card', 'panel']),
-  cols: PropTypes.oneOf([1, 2, 3]),
 };
 
-//Wrapper for StatCardLayout which applies the syling.
-export default function StatsCard({ stats, variant = 'card', cols = 2 }) {
-  return <StatCardLayout stats={stats} variant={variant} cols={cols} />;
+export default function StatsCard({ item, stats, variant = 'card' }) {
+  if (variant === 'panel') {
+    return <StatCardLayout stats={stats} />;
+  }
+  return <StatCardItem item={item} />;
 }
 
 StatsCard.propTypes = {
-  stats: PropTypes.array.isRequired,
+  item: PropTypes.object,
+  stats: PropTypes.array,
   variant: PropTypes.oneOf(['card', 'panel']),
-  cols: PropTypes.oneOf([1, 2, 3]),
 };

--- a/src/components/ui/molecule/statsCard.jsx
+++ b/src/components/ui/molecule/statsCard.jsx
@@ -72,10 +72,12 @@ function StatCardLayout({ stats, variant = 'panel' }) {
               <div className="text-paragraph-base text-content-secondary">
                 {item.description}
               </div>
-              <div className="text-paragraph-base text-content-secondary py-1">
-                {/* National average:{' '}
-                {formatValue(nationalAverage, item.isCurrency)} */}
-              </div>
+              {(item.detail1 || item.detail2) && (
+                <div className="text-paragraph-base text-content-secondary mt-3 flex flex-col gap-0.5">
+                  {item.detail1 && <span>{item.detail1}</span>}
+                  {item.detail2 && <span>{item.detail2}</span>}
+                </div>
+              )}
             </div>
           );
         })}
@@ -92,6 +94,8 @@ StatCardLayout.propTypes = {
       rating: PropTypes.string,
       isCurrency: PropTypes.bool,
       description: PropTypes.string,
+      detail1: PropTypes.string,
+      detail2: PropTypes.string,
     }),
   ).isRequired,
   variant: PropTypes.oneOf(['card', 'panel']),

--- a/src/components/ui/molecule/statsCard.jsx
+++ b/src/components/ui/molecule/statsCard.jsx
@@ -20,9 +20,16 @@ import PropTypes from 'prop-types';
  *    <StatsCard stats={data} variant="card" />
  */
 
+const cardColsClass = {
+  1: 'sm:grid-cols-1',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+};
+
 const variants = {
   card: {
-    wrapper: 'mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2',
+    wrapper: (cols) =>
+      `mt-5 grid grid-cols-1 gap-5 ${cardColsClass[cols] ?? 'sm:grid-cols-2'}`,
     item: 'border-border-primary text-label-lg overflow-hidden rounded-lg border bg-white px-4 pt-5 pb-16 shadow-sm',
   },
   panel: {
@@ -54,11 +61,13 @@ function normalizeKey(str) {
 }
 
 //StatCardLayout handles all the styling
-function StatCardLayout({ stats, variant = 'panel' }) {
+function StatCardLayout({ stats, variant = 'panel', cols = 2 }) {
   const styles = variants[variant];
+  const wrapperClass =
+    typeof styles.wrapper === 'function' ? styles.wrapper(cols) : styles.wrapper;
   return (
     <div>
-      <dl className={styles.wrapper} aria-label="Statistics summary">
+      <dl className={wrapperClass} aria-label="Statistics summary">
         {stats.map((item, i) => {
           return (
             <div key={item.key + i} className={styles.item}>
@@ -108,9 +117,16 @@ StatCardLayout.propTypes = {
     }),
   ).isRequired,
   variant: PropTypes.oneOf(['card', 'panel']),
+  cols: PropTypes.oneOf([1, 2, 3]),
 };
 
 //Wrapper for StatCardLayout which applies the syling.
-export default function StatsCard({ stats, variant = 'card' }) {
-  return <StatCardLayout stats={stats} variant={variant} />;
+export default function StatsCard({ stats, variant = 'card', cols = 2 }) {
+  return <StatCardLayout stats={stats} variant={variant} cols={cols} />;
 }
+
+StatsCard.propTypes = {
+  stats: PropTypes.array.isRequired,
+  variant: PropTypes.oneOf(['card', 'panel']),
+  cols: PropTypes.oneOf([1, 2, 3]),
+};

--- a/src/components/ui/molecule/tabs/deficienciesTab.jsx
+++ b/src/components/ui/molecule/tabs/deficienciesTab.jsx
@@ -30,6 +30,15 @@ export default function DeficienciesTab({ metricsSource, status, nationalBenchma
 
   return (
     <section>
+      {status === 'owner' && (
+        <div className="pt-8">
+          <p className="text-paragraph-lg">
+            Scores represent the{' '}
+            <span className="font-bold">weighted average </span>
+            across all facilities under this owner&apos;s management.
+          </p>
+        </div>
+      )}
       <div className="my-8">
         <div>
           <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">

--- a/src/components/ui/molecule/tabs/deficienciesTab.jsx
+++ b/src/components/ui/molecule/tabs/deficienciesTab.jsx
@@ -17,16 +17,16 @@ import {
  * - Switches between facility and owner metric builders based on status
  * - Renders each group using the shared StatsCard layout
  */
-export default function DeficienciesTab({ metricsSource, status }) {
+export default function DeficienciesTab({ metricsSource, status, nationalBenchmarks }) {
   const deficienciesStats =
     status === 'owner'
       ? buildOwnerDeficienciesStats(metricsSource)
-      : buildFacilityDeficienciesStats(metricsSource);
+      : buildFacilityDeficienciesStats(metricsSource, nationalBenchmarks);
 
   const penaltiesStats =
     status === 'owner'
       ? buildOwnerPenaltiesStats(metricsSource)
-      : buildFacilityPenaltiesStats(metricsSource);
+      : buildFacilityPenaltiesStats(metricsSource, nationalBenchmarks);
 
   return (
     <section>
@@ -52,4 +52,5 @@ export default function DeficienciesTab({ metricsSource, status }) {
 DeficienciesTab.propTypes = {
   metricsSource: PropTypes.object,
   status: PropTypes.oneOf(['facility', 'owner']),
+  nationalBenchmarks: PropTypes.object,
 };

--- a/src/components/ui/molecule/tabs/deficienciesTab.jsx
+++ b/src/components/ui/molecule/tabs/deficienciesTab.jsx
@@ -1,14 +1,55 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Heading } from '../../atom/heading';
+import StatsCard from '../statsCard';
+import {
+  buildFacilityDeficienciesStats,
+  buildFacilityPenaltiesStats,
+  buildOwnerDeficienciesStats,
+  buildOwnerPenaltiesStats,
+} from '../../../../lib/deficienciesMetrics';
 
-export default function DeficienciesTab() {
+/**
+ * Deficiencies & Penalties tab content.
+ *
+ * Responsibilities:
+ * - Builds deficiency and penalty stat groups from the provided data source
+ * - Switches between facility and owner metric builders based on status
+ * - Renders each group using the shared StatsCard layout
+ */
+export default function DeficienciesTab({ metricsSource, status }) {
+  const deficienciesStats =
+    status === 'owner'
+      ? buildOwnerDeficienciesStats(metricsSource)
+      : buildFacilityDeficienciesStats(metricsSource);
+
+  const penaltiesStats =
+    status === 'owner'
+      ? buildOwnerPenaltiesStats(metricsSource)
+      : buildFacilityPenaltiesStats(metricsSource);
+
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
-      <p className="text-heading-sm font-semibold text-foreground mb-2">
-        Coming Soon
-      </p>
-      <p className="text-paragraph-sm text-muted-foreground max-w-sm">
-        Deficiency and penalty data from inspection reports will be available here in a future update.
-      </p>
-    </div>
+    <section>
+      <div className="my-8">
+        <div>
+          <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
+            Deficiencies from Inspection Reports
+          </Heading>
+          <StatsCard stats={deficienciesStats} variant="card" />
+        </div>
+
+        <div className="pb-8">
+          <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
+            Penalties
+          </Heading>
+          <StatsCard stats={penaltiesStats} variant="card" />
+        </div>
+      </div>
+    </section>
   );
 }
+
+DeficienciesTab.propTypes = {
+  metricsSource: PropTypes.object,
+  status: PropTypes.oneOf(['facility', 'owner']),
+};

--- a/src/components/ui/molecule/tabs/deficienciesTab.jsx
+++ b/src/components/ui/molecule/tabs/deficienciesTab.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Heading } from '../../atom/heading';
 import StatsCard from '../statsCard';
+import ListContainer, { ListContainerGrid } from '../../organism/ListContainer';
 import {
   buildFacilityDeficienciesStats,
   buildFacilityPenaltiesStats,
@@ -15,9 +16,13 @@ import {
  * Responsibilities:
  * - Builds deficiency and penalty stat groups from the provided data source
  * - Switches between facility and owner metric builders based on status
- * - Renders each group using the shared StatsCard layout
+ * - Renders each group using ListContainer + ListContainerGrid + StatsCard
  */
-export default function DeficienciesTab({ metricsSource, status, nationalBenchmarks }) {
+export default function DeficienciesTab({
+  metricsSource,
+  status,
+  nationalBenchmarks,
+}) {
   const deficienciesStats =
     status === 'owner'
       ? buildOwnerDeficienciesStats(metricsSource)
@@ -44,14 +49,24 @@ export default function DeficienciesTab({ metricsSource, status, nationalBenchma
           <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
             Deficiencies from Inspection Reports
           </Heading>
-          <StatsCard stats={deficienciesStats} variant="card" cols={2} />
+          <ListContainer
+            items={deficienciesStats}
+            LayoutSelector={ListContainerGrid}
+            ListContent={StatsCard}
+            layoutProps={{ cols: 1 }}
+          />
         </div>
 
         <div className="pb-8">
           <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
             Penalties
           </Heading>
-          <StatsCard stats={penaltiesStats} variant="card" cols={3} />
+          <ListContainer
+            items={penaltiesStats}
+            LayoutSelector={ListContainerGrid}
+            ListContent={StatsCard}
+            layoutProps={{ cols: 3 }}
+          />
         </div>
       </div>
     </section>

--- a/src/components/ui/molecule/tabs/deficienciesTab.jsx
+++ b/src/components/ui/molecule/tabs/deficienciesTab.jsx
@@ -44,14 +44,14 @@ export default function DeficienciesTab({ metricsSource, status, nationalBenchma
           <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
             Deficiencies from Inspection Reports
           </Heading>
-          <StatsCard stats={deficienciesStats} variant="card" />
+          <StatsCard stats={deficienciesStats} variant="card" cols={2} />
         </div>
 
         <div className="pb-8">
           <Heading level={3} className="text-heading-sm mt-8 mb-4 font-bold">
             Penalties
           </Heading>
-          <StatsCard stats={penaltiesStats} variant="card" />
+          <StatsCard stats={penaltiesStats} variant="card" cols={3} />
         </div>
       </div>
     </section>

--- a/src/components/ui/molecule/tabs/staffingTab.jsx
+++ b/src/components/ui/molecule/tabs/staffingTab.jsx
@@ -4,7 +4,7 @@ import LayoutCard from '../../atom/layout-card';
 import CMSRating from '../CMSRating';
 import { Divider } from '../../atom/divider';
 import ListContainer, { ListContainerGrid } from '../../organism/ListContainer';
-import { StaffingStatCard } from '../listContainerContent';
+import StatsCard from '../statsCard';
 import {
   buildFacilityStaffingLevels,
   buildFacilityStaffingTurnover,
@@ -91,7 +91,8 @@ export default function StaffingTab({ items, status }) {
               <ListContainer
                 items={staffingLevelsStats}
                 LayoutSelector={ListContainerGrid}
-                ListContent={StaffingStatCard}
+                ListContent={StatsCard}
+                layoutProps={{ cols: 3 }}
               />
             </div>
             <Divider />
@@ -101,7 +102,8 @@ export default function StaffingTab({ items, status }) {
               <ListContainer
                 items={staffingTurnoverStats}
                 LayoutSelector={ListContainerGrid}
-                ListContent={StaffingStatCard}
+                ListContent={StatsCard}
+                layoutProps={{ cols: 3 }}
               />
             </div>
           </LayoutCard>

--- a/src/components/ui/organism/ListContainer.jsx
+++ b/src/components/ui/organism/ListContainer.jsx
@@ -32,6 +32,7 @@ export default function ListContainer({
   LayoutSelector,
   ListContent,
   variant = 'static',
+  layoutProps = {},
 }) {
   const renderListItem = (item) => {
     if (variant === 'static') {
@@ -66,7 +67,7 @@ export default function ListContainer({
 
   return (
     <div>
-      <LayoutSelector items={items} renderItem={renderListItem} />
+      <LayoutSelector items={items} renderItem={renderListItem} {...layoutProps} />
     </div>
   );
 }
@@ -76,6 +77,7 @@ ListContainer.propTypes = {
   LayoutSelector: PropTypes.elementType.isRequired,
   ListContent: PropTypes.elementType.isRequired,
   variant: PropTypes.oneOf(['static', 'expandable']),
+  layoutProps: PropTypes.object,
 };
 
 /**
@@ -123,14 +125,23 @@ ListContainerSeparate.propTypes = {
   renderItem: PropTypes.func.isRequired,
 };
 
+const gridColsClass = {
+  1: 'sm:grid-cols-1',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+};
+
 /**
  * Grid layout used for card-based content such as staffing stat cards.
+ * Pass cols (1–3) to set the sm: breakpoint column count.
+ * Without cols, defaults to md:grid-cols-2 xl:grid-cols-3.
  */
-export function ListContainerGrid({ items = [], renderItem }) {
+export function ListContainerGrid({ items = [], renderItem, cols }) {
+  const colsClass = cols != null ? gridColsClass[cols] : 'md:grid-cols-2 xl:grid-cols-3';
   return (
     <ul
       role="list"
-      className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+      className={`mt-4 grid grid-cols-1 gap-4 ${colsClass}`}
     >
       {items.map((item, i) => (
         <li key={item.id || i}>{renderItem(item)}</li>
@@ -142,4 +153,5 @@ export function ListContainerGrid({ items = [], renderItem }) {
 ListContainerGrid.propTypes = {
   items: PropTypes.array,
   renderItem: PropTypes.func.isRequired,
+  cols: PropTypes.oneOf([1, 2, 3]),
 };

--- a/src/lib/deficienciesMetrics.js
+++ b/src/lib/deficienciesMetrics.js
@@ -1,4 +1,4 @@
-import { formatMetricValue, expandStateAbbreviation } from './stringFormatters';
+import { formatMetricValue, expandStateAbbreviation, formatUSD } from './stringFormatters';
 
 /**
  * Deficiencies & Penalties metric config and builder helpers.
@@ -25,6 +25,15 @@ const facilityDeficienciesConfig = [
 ];
 
 const facilityPenaltiesConfig = [
+  {
+    key: 'Total Penalties',
+    description: 'Total number of penalties issued against this facility',
+    valueKey: 'total_penalties',
+    ratingKey: 'cmpr_total_penalties',
+    stateAvgKey: 'state_total_penalties',
+    nationalAvgKey: 'national_total_penalties',
+    isCurrency: false,
+  },
   {
     key: 'Number of Fines',
     description: 'Total fines issued against this facility',
@@ -81,8 +90,9 @@ const ownerPenaltiesConfig = [
 export function buildFacilityDeficienciesStats(metricsSource, nationalBenchmarks) {
   const stateName = expandStateAbbreviation(metricsSource?.state);
   return facilityDeficienciesConfig.map((metric) => {
-    const stateAvg = formatMetricValue(metricsSource?.[metric.stateAvgKey]);
-    const nationalAvg = formatMetricValue(nationalBenchmarks?.[metric.nationalAvgKey]);
+    const format = metric.isCurrency ? formatUSD : formatMetricValue;
+    const stateAvg = format(metricsSource?.[metric.stateAvgKey]);
+    const nationalAvg = format(nationalBenchmarks?.[metric.nationalAvgKey]);
     return {
       key: metric.key,
       description: metric.description,
@@ -98,8 +108,9 @@ export function buildFacilityDeficienciesStats(metricsSource, nationalBenchmarks
 export function buildFacilityPenaltiesStats(metricsSource, nationalBenchmarks) {
   const stateName = expandStateAbbreviation(metricsSource?.state);
   return facilityPenaltiesConfig.map((metric) => {
-    const stateAvg = formatMetricValue(metricsSource?.[metric.stateAvgKey]);
-    const nationalAvg = formatMetricValue(nationalBenchmarks?.[metric.nationalAvgKey]);
+    const format = metric.isCurrency ? formatUSD : formatMetricValue;
+    const stateAvg = format(metricsSource?.[metric.stateAvgKey]);
+    const nationalAvg = format(nationalBenchmarks?.[metric.nationalAvgKey]);
     return {
       key: metric.key,
       description: metric.description,

--- a/src/lib/deficienciesMetrics.js
+++ b/src/lib/deficienciesMetrics.js
@@ -8,7 +8,7 @@ import { formatMetricValue, expandStateAbbreviation, formatUSD } from './stringF
  * - Transforms raw API fields into the display-ready objects expected by StatsCard
  *
  * Pattern:
- * - Facility builders read state averages from metricsSource and surface them as detail1
+ * - Facility builders surface state and national averages as detail1/detail2
  * - Owner builders surface median and std dev as detail1/detail2 (placeholders until backend provides real data)
  */
 
@@ -62,7 +62,6 @@ const ownerDeficienciesConfig = [
     description: 'Average number of deficiencies found in affiliated homes in the last three years',
     valueKey: 'cms_owner_average_deficiencies',
     isCurrency: false,
-    decimals: 1,
     medianKey: 'N/A',
     stdDevKey: 'N/A',
   },
@@ -123,33 +122,24 @@ export function buildFacilityPenaltiesStats(metricsSource, nationalBenchmarks) {
   });
 }
 
-export function buildOwnerDeficienciesStats(metricsSource) {
-  return ownerDeficienciesConfig.map((metric) => {
-    const raw = metricsSource?.[metric.valueKey];
-    const stat =
-      raw == null
-        ? 'N/A'
-        : metric.decimals != null
-          ? raw.toFixed(metric.decimals)
-          : raw;
-    return {
-      key: metric.key,
-      description: metric.description,
-      stat,
-      isCurrency: metric.isCurrency,
-      detail1: `Median: ${metric.medianKey}`,
-      detail2: `Std Dev: ${metric.stdDevKey}`,
-    };
-  });
-}
+function buildOwnerStats(config, metricsSource) {
+  const format = (metric, value) =>
+    metric.isCurrency ? formatUSD(value) : formatMetricValue(value);
 
-export function buildOwnerPenaltiesStats(metricsSource) {
-  return ownerPenaltiesConfig.map((metric) => ({
+  return config.map((metric) => ({
     key: metric.key,
     description: metric.description,
-    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+    stat: format(metric, metricsSource?.[metric.valueKey]),
     isCurrency: metric.isCurrency,
     detail1: `Median: ${metric.medianKey}`,
     detail2: `Std Dev: ${metric.stdDevKey}`,
   }));
+}
+
+export function buildOwnerDeficienciesStats(metricsSource) {
+  return buildOwnerStats(ownerDeficienciesConfig, metricsSource);
+}
+
+export function buildOwnerPenaltiesStats(metricsSource) {
+  return buildOwnerStats(ownerPenaltiesConfig, metricsSource);
 }

--- a/src/lib/deficienciesMetrics.js
+++ b/src/lib/deficienciesMetrics.js
@@ -1,0 +1,115 @@
+/**
+ * Deficiencies & Penalties metric config and builder helpers.
+ *
+ * Purpose:
+ * - Defines the field-to-card mapping for the Deficiencies & Penalties tab
+ * - Transforms raw API fields into the display-ready objects expected by StatsCard
+ *
+ * Pattern:
+ * - Config arrays describe which backend fields map to each stat card
+ * - Builder functions read those configs and return normalized UI data
+ * - Facility builders include CMS comparison ratings when available
+ */
+
+const facilityDeficienciesConfig = [
+  {
+    key: 'Total Deficiencies',
+    description: 'Number of deficiencies found during health inspections in the last three years',
+    valueKey: 'health_deficiencies',
+    ratingKey: 'cmpr_health_deficiencies',
+    isCurrency: false,
+  },
+];
+
+const facilityPenaltiesConfig = [
+  {
+    key: 'Number of Fines',
+    description: 'Total number of fines issued against this facility',
+    valueKey: 'number_of_fines',
+    ratingKey: 'cmpr_number_of_fines',
+    isCurrency: false,
+  },
+  {
+    key: 'Total Fine Amount',
+    description: 'Total dollar amount of all fines issued against this facility',
+    valueKey: 'total_amount_of_fines_in_usd',
+    ratingKey: 'cmpr_total_amount_of_fines_in_usd',
+    isCurrency: true,
+  },
+];
+
+const ownerDeficienciesConfig = [
+  {
+    key: 'Average Total Deficiencies',
+    description: 'Average number of deficiencies found in affiliated homes in the last three years',
+    valueKey: 'cms_owner_average_deficiencies',
+    isCurrency: false,
+    decimals: 1,
+  },
+];
+
+const ownerPenaltiesConfig = [
+  {
+    key: 'Average Number of Penalties',
+    description: 'Average number of penalties issued against affiliated homes',
+    valueKey: 'cms_owner_average_penalties',
+    isCurrency: false,
+  },
+  {
+    key: 'Average Fine Amount',
+    description: 'Average total fines issued against affiliated homes',
+    valueKey: 'cms_owner_average_fines',
+    isCurrency: true,
+  },
+];
+
+export function buildFacilityDeficienciesStats(metricsSource) {
+  return facilityDeficienciesConfig.map((metric) => ({
+    key: metric.key,
+    description: metric.description,
+    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+    rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
+    isCurrency: metric.isCurrency,
+  }));
+}
+
+export function buildFacilityPenaltiesStats(metricsSource) {
+  return facilityPenaltiesConfig.map((metric) => ({
+    key: metric.key,
+    description: metric.description,
+    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+    rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
+    isCurrency: metric.isCurrency,
+  }));
+}
+
+export function buildOwnerDeficienciesStats(metricsSource) {
+  return ownerDeficienciesConfig.map((metric) => {
+    const raw = metricsSource?.[metric.valueKey];
+    const stat =
+      raw == null
+        ? 'N/A'
+        : metric.decimals != null
+          ? raw.toFixed(metric.decimals)
+          : raw;
+    return {
+      key: metric.key,
+      description: metric.description,
+      stat,
+      isCurrency: metric.isCurrency,
+    };
+  });
+}
+
+export function buildOwnerPenaltiesStats(metricsSource) {
+  return ownerPenaltiesConfig.map((metric) => {
+    const raw = metricsSource?.[metric.valueKey];
+    const stat = raw == null ? 'N/A' : raw;
+    return {
+      key: metric.key,
+      description: metric.description,
+      stat,
+      isCurrency: metric.isCurrency,
+    };
+  });
+}

--- a/src/lib/deficienciesMetrics.js
+++ b/src/lib/deficienciesMetrics.js
@@ -1,3 +1,5 @@
+import { formatMetricValue, expandStateAbbreviation } from './stringFormatters';
+
 /**
  * Deficiencies & Penalties metric config and builder helpers.
  *
@@ -6,17 +8,18 @@
  * - Transforms raw API fields into the display-ready objects expected by StatsCard
  *
  * Pattern:
- * - Config arrays describe which backend fields map to each stat card
- * - Builder functions read those configs and return normalized UI data
- * - Facility builders include CMS comparison ratings when available
+ * - Facility builders read state averages from metricsSource and surface them as detail1
+ * - Owner builders surface median and std dev as detail1/detail2 (placeholders until backend provides real data)
  */
 
 const facilityDeficienciesConfig = [
   {
     key: 'Total Deficiencies',
-    description: 'Number of deficiencies found during health inspections in the last three years',
+    description: 'Total deficiencies found in the past year',
     valueKey: 'health_deficiencies',
     ratingKey: 'cmpr_health_deficiencies',
+    stateAvgKey: 'state_health_deficiencies',
+    nationalAvgKey: 'national_health_deficiencies',
     isCurrency: false,
   },
 ];
@@ -24,9 +27,11 @@ const facilityDeficienciesConfig = [
 const facilityPenaltiesConfig = [
   {
     key: 'Number of Fines',
-    description: 'Total number of fines issued against this facility',
+    description: 'Total fines issued against this facility',
     valueKey: 'number_of_fines',
     ratingKey: 'cmpr_number_of_fines',
+    stateAvgKey: 'state_number_of_fines',
+    nationalAvgKey: 'national_number_of_fines',
     isCurrency: false,
   },
   {
@@ -34,10 +39,14 @@ const facilityPenaltiesConfig = [
     description: 'Total dollar amount of all fines issued against this facility',
     valueKey: 'total_amount_of_fines_in_usd',
     ratingKey: 'cmpr_total_amount_of_fines_in_usd',
+    stateAvgKey: 'state_total_amount_of_fines_in_usd',
+    nationalAvgKey: 'national_total_amount_of_fines_in_usd',
     isCurrency: true,
   },
 ];
 
+// NOTE: owner median/std-dev values are placeholders until backend provides
+// owner-level deficiency and penalty distribution data.
 const ownerDeficienciesConfig = [
   {
     key: 'Average Total Deficiencies',
@@ -45,6 +54,8 @@ const ownerDeficienciesConfig = [
     valueKey: 'cms_owner_average_deficiencies',
     isCurrency: false,
     decimals: 1,
+    medianKey: 'N/A',
+    stdDevKey: 'N/A',
   },
 ];
 
@@ -54,33 +65,51 @@ const ownerPenaltiesConfig = [
     description: 'Average number of penalties issued against affiliated homes',
     valueKey: 'cms_owner_average_penalties',
     isCurrency: false,
+    medianKey: 'N/A',
+    stdDevKey: 'N/A',
   },
   {
     key: 'Average Fine Amount',
     description: 'Average total fines issued against affiliated homes',
     valueKey: 'cms_owner_average_fines',
     isCurrency: true,
+    medianKey: 'N/A',
+    stdDevKey: 'N/A',
   },
 ];
 
-export function buildFacilityDeficienciesStats(metricsSource) {
-  return facilityDeficienciesConfig.map((metric) => ({
-    key: metric.key,
-    description: metric.description,
-    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
-    rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
-    isCurrency: metric.isCurrency,
-  }));
+export function buildFacilityDeficienciesStats(metricsSource, nationalBenchmarks) {
+  const stateName = expandStateAbbreviation(metricsSource?.state);
+  return facilityDeficienciesConfig.map((metric) => {
+    const stateAvg = formatMetricValue(metricsSource?.[metric.stateAvgKey]);
+    const nationalAvg = formatMetricValue(nationalBenchmarks?.[metric.nationalAvgKey]);
+    return {
+      key: metric.key,
+      description: metric.description,
+      stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+      rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
+      isCurrency: metric.isCurrency,
+      detail1: stateAvg !== 'N/A' ? `${stateName} average: ${stateAvg}` : null,
+      detail2: nationalAvg !== 'N/A' ? `National average: ${nationalAvg}` : null,
+    };
+  });
 }
 
-export function buildFacilityPenaltiesStats(metricsSource) {
-  return facilityPenaltiesConfig.map((metric) => ({
-    key: metric.key,
-    description: metric.description,
-    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
-    rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
-    isCurrency: metric.isCurrency,
-  }));
+export function buildFacilityPenaltiesStats(metricsSource, nationalBenchmarks) {
+  const stateName = expandStateAbbreviation(metricsSource?.state);
+  return facilityPenaltiesConfig.map((metric) => {
+    const stateAvg = formatMetricValue(metricsSource?.[metric.stateAvgKey]);
+    const nationalAvg = formatMetricValue(nationalBenchmarks?.[metric.nationalAvgKey]);
+    return {
+      key: metric.key,
+      description: metric.description,
+      stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+      rating: metricsSource?.[metric.ratingKey] ?? 'N/A',
+      isCurrency: metric.isCurrency,
+      detail1: stateAvg !== 'N/A' ? `${stateName} average: ${stateAvg}` : null,
+      detail2: nationalAvg !== 'N/A' ? `National average: ${nationalAvg}` : null,
+    };
+  });
 }
 
 export function buildOwnerDeficienciesStats(metricsSource) {
@@ -97,19 +126,19 @@ export function buildOwnerDeficienciesStats(metricsSource) {
       description: metric.description,
       stat,
       isCurrency: metric.isCurrency,
+      detail1: `Median: ${metric.medianKey}`,
+      detail2: `Std Dev: ${metric.stdDevKey}`,
     };
   });
 }
 
 export function buildOwnerPenaltiesStats(metricsSource) {
-  return ownerPenaltiesConfig.map((metric) => {
-    const raw = metricsSource?.[metric.valueKey];
-    const stat = raw == null ? 'N/A' : raw;
-    return {
-      key: metric.key,
-      description: metric.description,
-      stat,
-      isCurrency: metric.isCurrency,
-    };
-  });
+  return ownerPenaltiesConfig.map((metric) => ({
+    key: metric.key,
+    description: metric.description,
+    stat: metricsSource?.[metric.valueKey] ?? 'N/A',
+    isCurrency: metric.isCurrency,
+    detail1: `Median: ${metric.medianKey}`,
+    detail2: `Std Dev: ${metric.stdDevKey}`,
+  }));
 }

--- a/src/lib/staffingMetrics.js
+++ b/src/lib/staffingMetrics.js
@@ -6,7 +6,7 @@ import { formatMetricValue, expandStateAbbreviation } from './stringFormatters';
  * Purpose:
  * - Defines the field-to-card mapping for staffing tabs
  * - Keeps facility and owner staffing metric definitions in one place
- * - Transforms raw API fields into the display-ready objects expected by StaffingStatCard
+ * - Transforms raw API fields into the display-ready objects expected by StatsCard
  *
  * Pattern:
  * - Config arrays describe which backend fields belong to each staffing card
@@ -152,12 +152,12 @@ export function buildFacilityStaffingLevels(metricsSource) {
 
     return {
       id: metric.id,
-      title: metric.title,
+      key: metric.title,
       description: metric.description,
       stat,
       displayStat: formatDisplayValue(metric, stat),
       rating: metricsSource?.[metric.ratingKey] ?? null,
-      detail: `${stateName} average: ${stateAvg}`,
+      detail1: `${stateName} average: ${stateAvg}`,
     };
   });
 }
@@ -173,12 +173,12 @@ export function buildFacilityStaffingTurnover(metricsSource) {
 
     return {
       id: metric.id,
-      title: metric.title,
+      key: metric.title,
       description: metric.description,
       stat,
       displayStat: formatDisplayValue(metric, stat),
       rating: metric.ratingKey ? metricsSource?.[metric.ratingKey] : null,
-      detail: stateAvg ? `${stateName} average: ${stateAvg}` : 'N/A',
+      detail1: stateAvg ? `${stateName} average: ${stateAvg}` : 'N/A',
     };
   });
 }
@@ -191,11 +191,11 @@ export function buildOwnerStaffingLevels(metricsSource) {
 
     return {
       id: metric.id,
-      title: metric.title,
+      key: metric.title,
       description: metric.description,
       stat,
       displayStat: formatDisplayValue(metric, stat),
-      detail: `Median: ${metric.median}`,
+      detail1: `Median: ${metric.median}`,
     };
   });
 }
@@ -206,11 +206,11 @@ export function buildOwnerStaffingTurnover(metricsSource) {
 
     return {
       id: metric.id,
-      title: metric.title,
+      key: metric.title,
       description: metric.description,
       stat,
       displayStat: formatDisplayValue(metric, stat),
-      detail: `Median: ${metric.median}`,
+      detail1: `Median: ${metric.median}`,
     };
   });
 }

--- a/src/pages/FacilityProfile.jsx
+++ b/src/pages/FacilityProfile.jsx
@@ -150,7 +150,7 @@ export default function FacilityProfile() {
                   //As of 3/16/26 we are holding off on deficiencies
                   //4/17 Tyler requested tab be visible with coming soon
                   case 'Deficiencies & Penalties':
-                    return <DeficienciesTab items={facility} />;
+                    return <DeficienciesTab metricsSource={facility} status="facility" />;
 
                   case 'Clinical Quality Measures':
                     return (

--- a/src/pages/FacilityProfile.jsx
+++ b/src/pages/FacilityProfile.jsx
@@ -150,7 +150,7 @@ export default function FacilityProfile() {
                   //As of 3/16/26 we are holding off on deficiencies
                   //4/17 Tyler requested tab be visible with coming soon
                   case 'Deficiencies & Penalties':
-                    return <DeficienciesTab metricsSource={facility} status="facility" />;
+                    return <DeficienciesTab metricsSource={facility} status="facility" nationalBenchmarks={nationalBenchmarks} />;
 
                   case 'Clinical Quality Measures':
                     return (

--- a/src/pages/OwnersProfile.jsx
+++ b/src/pages/OwnersProfile.jsx
@@ -140,7 +140,7 @@ export default function OwnersProfile() {
                   //As of 3/16/26 we are holding off on deficiencies
                   //4/17 Tyler requested tab be visible with coming soon
                   case 'Deficiencies & Penalties':
-                    return <DeficienciesTab items={owner} />;
+                    return <DeficienciesTab metricsSource={owner} status="owner" />;
 
                   case 'Clinical Quality Measures':
                     return (

--- a/src/stories/molecule/StatsCard.stories.jsx
+++ b/src/stories/molecule/StatsCard.stories.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import StatsCard from '../../components/ui/molecule/statsCard';
 
 export default {
@@ -10,26 +11,20 @@ export default {
   },
 };
 
+// The card variant renders a single item — it is used as ListContent inside
+// ListContainer, which supplies one item per grid cell.
 export const cardVariant = (args) => <StatsCard {...args} />;
 
 cardVariant.args = {
   variant: 'card',
-  stats: [
-    {
-      id: 1,
-      key: 'Total Penalties',
-      stat: '17',
-      rating: 'Above Average',
-      nationalAveragePenalties: '3',
-    },
-    {
-      id: 2,
-      key: 'Total Fines',
-      stat: '753,581',
-      rating: 'Below Average',
-      nationalAverageFines: '48,371',
-    },
-  ],
+  item: {
+    key: 'Total Penalties',
+    stat: '17',
+    rating: 'Above Average',
+    description: 'Total number of penalties issued against this facility',
+    detail1: 'Hawaii average: 0.7',
+    detail2: 'National average: 1.1',
+  },
 };
 
 export const panelVariant = (args) => <StatsCard {...args} />;


### PR DESCRIPTION
This is the V1 of the Deficiencies & Penalties tab. It uses the same config-building convention as the other tabs. This branch also refactors how stat cards render so the Deficiencies and Staffing tabs share one card component driven by ListContainer.

**Deficiencies & Penalties tab**

- deficienciesTab.jsx — built from scratch. Switches between facility and owner builders based on the status prop. Includes the weighted-average context note for the owner view, consistent with clinicalQualityTab.jsx. Renders the deficiency and penalty groups through ListContainer + ListContainerGrid + StatsCard.
- deficienciesMetrics.js — facility/owner config + builders. Facility surfaces state and national averages as detail1/detail2; owner surfaces median/std-dev placeholders.
- FacilityProfile.jsx / OwnersProfile.jsx — updated DeficienciesTab call with correct props (metricsSource, status, nationalBenchmarks for facility).
- Stat card unification
- statsCard.jsx — card variant is now a single-item renderer (accepts one item) so it can be used as ListContent inside ListContainer; panel variant unchanged. Supports detail1/detail2 rendered below the description. JSDoc/example updated to the full data contract.
- ListContainer.jsx — added layoutProps passthrough on ListContainer and a cols prop (1–3) on ListContainerGrid for explicit, responsive column control.
- staffingTab.jsx / staffingMetrics.js — Staffing tab migrated onto the shared StatsCard; staffing metric shape standardized (title → key, detail → detail1).
- listContainerContent.jsx — removed the now-redundant StaffingStatCard.
- StatsCard.stories.jsx — updated to the new single-item card API.

**Notes**

- Owner median/std-dev values are 'N/A' placeholders — real values pending backend support.
- National benchmark field names follow the existing national_ prefix convention.

**Next update**
We need a list-item component for deficiencies context, but we don't yet have all the fields Nick's design requires. The reports URL currently has the date attached to the field; Rahul will break that into separate fields in the data. That leaves date and report URL as our only two fields for any list-item component, so we'll ship a simple V1 card. The DB needs these changes before it can go live.