### PR TITLE
Shareability v1: copy/export controls for AI chat and charts (Merge 1st)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+CLAUDE.local.md
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "framer-motion": "^12.12.1",
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
+        "html-to-image": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -6193,6 +6194,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^12.12.1",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",
+    "html-to-image": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import {
   BarChart,
   Bar,
@@ -12,9 +13,9 @@ import {
   Scatter,
   ResponsiveContainer,
 } from 'recharts';
-import { TableCellsIcon } from '@heroicons/react/24/outline';
+import { TableCellsIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { ShareButton, ShareButtonRow } from './shareability';
-import { downloadCsv } from '../../../lib/shareActions';
+import { downloadCsv, downloadPng } from '../../../lib/shareActions';
 import { slugify } from '../../../lib/slugify';
 
 /**
@@ -100,15 +101,24 @@ ChartXTick.propTypes = {
 };
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
-function ChartWrapper({ title, description, children, chart }) {
+function ChartWrapper({ title, description, children, chart, isLatest }) {
+  const cardRef = useRef(null);
+
   function handleDownloadCsv() {
     const { headers, rows } = chartToRows(chart);
     return downloadCsv(rows, `${slugify(title)}.csv`, headers);
   }
 
+  function handleDownloadPng() {
+    return downloadPng(cardRef.current, `${slugify(title)}.png`);
+  }
+
   return (
-    <>
-      <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
+    <div className="group">
+      <div
+        ref={cardRef}
+        className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm"
+      >
         <p className="text-label-lg text-core-black">{title}</p>
         {description && (
           <p className="text-paragraph-base text-content-secondary mt-1">
@@ -117,8 +127,18 @@ function ChartWrapper({ title, description, children, chart }) {
         )}
         <div className="mt-4">{children}</div>
       </div>
-      <div className="mt-3">
+      <div
+        className={clsx(
+          'mt-3 transition-opacity',
+          isLatest ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        )}
+      >
         <ShareButtonRow>
+          <ShareButton
+            icon={PhotoIcon}
+            label="Download PNG"
+            onClick={handleDownloadPng}
+          />
           <ShareButton
             icon={TableCellsIcon}
             label="Download data as CSV"
@@ -126,13 +146,14 @@ function ChartWrapper({ title, description, children, chart }) {
           />
         </ShareButtonRow>
       </div>
-    </>
+    </div>
   );
 }
 
 ChartWrapper.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
+  isLatest: PropTypes.bool,
   chart: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 };
@@ -448,18 +469,24 @@ export function chartToRows(chart) {
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */
-export default function ResearchChart({ chart }) {
+export default function ResearchChart({ chart, isLatest }) {
   const { chart_type, title, description, data } = chart;
   const View = VIEWS[chart_type];
   if (!View) return null;
   return (
-    <ChartWrapper title={title} description={description} chart={chart}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      chart={chart}
+      isLatest={isLatest}
+    >
       <View data={data} />
     </ChartWrapper>
   );
 }
 
 ResearchChart.propTypes = {
+  isLatest: PropTypes.bool,
   chart: PropTypes.shape({
     chart_type: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import {
   BarChart,
   Bar,
@@ -14,7 +13,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TableCellsIcon, PhotoIcon } from '@heroicons/react/24/outline';
-import { ShareButton, ShareButtonRow } from './shareability';
+import { ShareButton, ShareButtonRow, HoverReveal } from './shareability';
 import { downloadCsv, downloadPng } from '../../../lib/shareActions';
 import { slugify } from '../../../lib/slugify';
 
@@ -103,14 +102,18 @@ ChartXTick.propTypes = {
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
 function ChartWrapper({ title, description, children, chart, isLatest }) {
   const cardRef = useRef(null);
+  /* Falls back to a generic name when the title has no a-z0-9 characters for
+     slugify to keep (e.g. emoji/symbols-only), so the download isn't a bare
+     ".csv"/".png" with no visible filename. */
+  const filenameBase = slugify(title) || 'chart';
 
   function handleDownloadCsv() {
     const { headers, rows } = chartToRows(chart);
-    return downloadCsv(rows, `${slugify(title)}.csv`, headers);
+    return downloadCsv(rows, `${filenameBase}.csv`, headers);
   }
 
   function handleDownloadPng() {
-    return downloadPng(cardRef.current, `${slugify(title)}.png`);
+    return downloadPng(cardRef.current, `${filenameBase}.png`);
   }
 
   return (
@@ -127,12 +130,7 @@ function ChartWrapper({ title, description, children, chart, isLatest }) {
         )}
         <div className="mt-4">{children}</div>
       </div>
-      <div
-        className={clsx(
-          'mt-3 transition-opacity',
-          isLatest ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-        )}
-      >
+      <HoverReveal show={isLatest} className="mt-3">
         <ShareButtonRow>
           <ShareButton
             icon={PhotoIcon}
@@ -145,7 +143,7 @@ function ChartWrapper({ title, description, children, chart, isLatest }) {
             onClick={handleDownloadCsv}
           />
         </ShareButtonRow>
-      </div>
+      </HoverReveal>
     </div>
   );
 }
@@ -158,12 +156,42 @@ ChartWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-function BarView({ data }) {
-  const bars = data.bars ?? data.items ?? [];
-  const normalized = bars.map((b) => ({
-    label: b.label ?? b.name,
-    value: b.value,
+/* Shared shape-unwrapping helpers — used by both the View that renders a
+   chart_type and the matching case in chartToRows below, so the LLM's
+   field-naming fallbacks (e.g. `bars` vs `items`) only have to be encoded
+   once per chart_type instead of drifting between render and CSV export. */
+function normalizeBarItems(data) {
+  const items = data.bars ?? data.items ?? [];
+  return items.map((item) => ({
+    label: item.label ?? item.name,
+    value: item.value,
   }));
+}
+
+function normalizeDistributionItems(data) {
+  const items = data.bins ?? data.bars ?? data.items ?? [];
+  return items.map((item) => ({
+    label: item.range ?? item.label ?? item.name,
+    value: item.count ?? item.value,
+  }));
+}
+
+function seriesValueAt(series, i) {
+  return series.values?.[i] ?? series.data?.[i];
+}
+
+function normalizeTableShape(data) {
+  const rows = data.rows ?? [];
+  if (!rows.length) return { columns: [], rows: [], isArrayRows: false };
+  const isArrayRows = Array.isArray(rows[0]);
+  const columns = isArrayRows
+    ? (data.columns ?? rows[0].map((_, i) => String(i)))
+    : Object.keys(rows[0]);
+  return { columns, rows, isArrayRows };
+}
+
+function BarView({ data }) {
+  const normalized = normalizeBarItems(data);
   const { top, bottom } = xMargins(normalized.map((b) => b.label));
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -190,7 +218,7 @@ function ComparisonBarView({ data }) {
   const normalized = categories.map((cat, i) => {
     const row = { category: cat };
     series.forEach((s) => {
-      row[s.name] = s.values?.[i] ?? s.data?.[i];
+      row[s.name] = seriesValueAt(s, i);
     });
     return row;
   });
@@ -253,11 +281,7 @@ ScatterView.propTypes = {
 };
 
 function DistributionView({ data }) {
-  const bins = data.bins ?? data.bars ?? data.items ?? [];
-  const normalized = bins.map((b) => ({
-    label: b.range ?? b.label ?? b.name,
-    value: b.count ?? b.value,
-  }));
+  const normalized = normalizeDistributionItems(data);
   const { top, bottom } = xMargins(normalized.map((b) => b.label));
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -324,15 +348,8 @@ KpiRowView.propTypes = {
 };
 
 function TableView({ data }) {
-  const rows = data.rows ?? [];
+  const { columns, rows, isArrayRows } = normalizeTableShape(data);
   if (!rows.length) return null;
-
-  // rows can be array-of-arrays (with a separate columns array)
-  // or array-of-objects (columns derived from keys)
-  const isArrayRows = Array.isArray(rows[0]);
-  const columns = isArrayRows
-    ? (data.columns ?? rows[0].map((_, i) => String(i)))
-    : Object.keys(rows[0]);
 
   const getCell = (row, col, i) =>
     isArrayRows ? (row[i] ?? '—') : (row[col] ?? '—');
@@ -402,20 +419,17 @@ export function chartToRows(chart) {
 
   switch (chart_type) {
     case 'bar': {
-      const items = data.bars ?? data.items ?? [];
+      const items = normalizeBarItems(data);
       return {
         headers: ['Label', 'Value'],
-        rows: items.map((item) => [item.label ?? item.name, item.value]),
+        rows: items.map((item) => [item.label, item.value]),
       };
     }
     case 'distribution': {
-      const items = data.bins ?? data.bars ?? data.items ?? [];
+      const items = normalizeDistributionItems(data);
       return {
         headers: ['Label', 'Value'],
-        rows: items.map((item) => [
-          item.range ?? item.label ?? item.name,
-          item.count ?? item.value,
-        ]),
+        rows: items.map((item) => [item.label, item.value]),
       };
     }
     case 'comparison_bar': {
@@ -424,7 +438,7 @@ export function chartToRows(chart) {
         headers: ['Category', ...series.map((s) => s.name)],
         rows: categories.map((cat, i) => [
           cat,
-          ...series.map((s) => s.values?.[i] ?? s.data?.[i]),
+          ...series.map((s) => seriesValueAt(s, i)),
         ]),
       };
     }
@@ -448,12 +462,11 @@ export function chartToRows(chart) {
       };
     }
     case 'table': {
-      const rows = data.rows ?? [];
+      const { columns, rows, isArrayRows } = normalizeTableShape(data);
       if (!rows.length) return { headers: [], rows: [] };
-      const isArrayRows = Array.isArray(rows[0]);
-      const columns = isArrayRows
-        ? (data.columns ?? rows[0].map((_, i) => String(i)))
-        : Object.keys(rows[0]);
+      /* Empty string, not TableView's '—' placeholder — a literal em-dash in
+         an otherwise-numeric CSV column would be misread as text by Excel/
+         pandas instead of as a missing value. */
       const getCell = (row, col, i) =>
         isArrayRows ? (row[i] ?? '') : (row[col] ?? '');
       return {

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -12,6 +12,10 @@ import {
   Scatter,
   ResponsiveContainer,
 } from 'recharts';
+import { TableCellsIcon } from '@heroicons/react/24/outline';
+import { ShareButton, ShareButtonRow } from './shareability';
+import { downloadCsv } from '../../../lib/shareActions';
+import { slugify } from '../../../lib/slugify';
 
 /**
  * ResearchChart — chart rendering for the Hefti Researcher right panel.
@@ -96,7 +100,12 @@ ChartXTick.propTypes = {
 };
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
-function ChartWrapper({ title, description, children }) {
+function ChartWrapper({ title, description, children, chart }) {
+  function handleDownloadCsv() {
+    const { headers, rows } = chartToRows(chart);
+    return downloadCsv(rows, `${slugify(title)}.csv`, headers);
+  }
+
   return (
     <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
       <p className="text-label-lg text-core-black">{title}</p>
@@ -106,6 +115,15 @@ function ChartWrapper({ title, description, children }) {
         </p>
       )}
       <div className="mt-4">{children}</div>
+      <div className="mt-3">
+        <ShareButtonRow>
+          <ShareButton
+            icon={TableCellsIcon}
+            label="Download data as CSV"
+            onClick={handleDownloadCsv}
+          />
+        </ShareButtonRow>
+      </div>
     </div>
   );
 }
@@ -113,6 +131,7 @@ function ChartWrapper({ title, description, children }) {
 ChartWrapper.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
+  chart: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 };
 
@@ -351,6 +370,79 @@ const VIEWS = {
   table: TableView,
 };
 
+/* Converts a chart's `data` into flat { headers, rows } for CSV export,
+   reusing the same per-chart_type unwrap logic as the View components above.
+   Lives here (not in shareActions.js) since this file already owns the
+   chart_type-to-shape knowledge — shareActions.js stays generic. */
+export function chartToRows(chart) {
+  const { chart_type, data } = chart;
+
+  switch (chart_type) {
+    case 'bar': {
+      const items = data.bars ?? data.items ?? [];
+      return {
+        headers: ['Label', 'Value'],
+        rows: items.map((item) => [item.label ?? item.name, item.value]),
+      };
+    }
+    case 'distribution': {
+      const items = data.bins ?? data.bars ?? data.items ?? [];
+      return {
+        headers: ['Label', 'Value'],
+        rows: items.map((item) => [
+          item.range ?? item.label ?? item.name,
+          item.count ?? item.value,
+        ]),
+      };
+    }
+    case 'comparison_bar': {
+      const { categories = [], series = [] } = data;
+      return {
+        headers: ['Category', ...series.map((s) => s.name)],
+        rows: categories.map((cat, i) => [
+          cat,
+          ...series.map((s) => s.values?.[i] ?? s.data?.[i]),
+        ]),
+      };
+    }
+    case 'scatter': {
+      const points = data.points ?? [];
+      return {
+        headers: [data.xLabel ?? 'x', data.yLabel ?? 'y'],
+        rows: points.map((p) => [p.x, p.y]),
+      };
+    }
+    case 'kpi_row': {
+      const kpis = data.kpis ?? [];
+      return {
+        headers: ['Label', 'Value', 'Unit', 'Delta'],
+        rows: kpis.map((kpi) => [
+          kpi.label,
+          kpi.value,
+          kpi.unit ?? '',
+          kpi.delta ?? '',
+        ]),
+      };
+    }
+    case 'table': {
+      const rows = data.rows ?? [];
+      if (!rows.length) return { headers: [], rows: [] };
+      const isArrayRows = Array.isArray(rows[0]);
+      const columns = isArrayRows
+        ? (data.columns ?? rows[0].map((_, i) => String(i)))
+        : Object.keys(rows[0]);
+      const getCell = (row, col, i) =>
+        isArrayRows ? (row[i] ?? '') : (row[col] ?? '');
+      return {
+        headers: columns,
+        rows: rows.map((row) => columns.map((col, j) => getCell(row, col, j))),
+      };
+    }
+    default:
+      return { headers: [], rows: [] };
+  }
+}
+
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */
@@ -359,7 +451,7 @@ export default function ResearchChart({ chart }) {
   const View = VIEWS[chart_type];
   if (!View) return null;
   return (
-    <ChartWrapper title={title} description={description}>
+    <ChartWrapper title={title} description={description} chart={chart}>
       <View data={data} />
     </ChartWrapper>
   );

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -107,14 +107,16 @@ function ChartWrapper({ title, description, children, chart }) {
   }
 
   return (
-    <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
-      <p className="text-label-lg text-core-black">{title}</p>
-      {description && (
-        <p className="text-paragraph-base text-content-secondary mt-1">
-          {description}
-        </p>
-      )}
-      <div className="mt-4">{children}</div>
+    <>
+      <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
+        <p className="text-label-lg text-core-black">{title}</p>
+        {description && (
+          <p className="text-paragraph-base text-content-secondary mt-1">
+            {description}
+          </p>
+        )}
+        <div className="mt-4">{children}</div>
+      </div>
       <div className="mt-3">
         <ShareButtonRow>
           <ShareButton
@@ -124,7 +126,7 @@ function ChartWrapper({ title, description, children, chart }) {
           />
         </ShareButtonRow>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -13,7 +13,7 @@ const CLICK_FEEDBACK_MS = 1200;
  * categories and expanding/collapsing between them) will be added here
  * later — this file is the single home for all shareability UI.
  */
-export function ShareButton({ icon: Icon, label, onClick, disabled, className }) {
+export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
   const timeoutRef = useRef(null);
 
@@ -37,10 +37,9 @@ export function ShareButton({ icon: Icon, label, onClick, disabled, className })
     <button
       type="button"
       onClick={handleClick}
-      disabled={disabled}
       title={label}
       className={clsx(
-        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-paragraph-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary text-paragraph-xs inline-flex items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
         className,
       )}
     >
@@ -58,7 +57,6 @@ ShareButton.propTypes = {
   icon: PropTypes.elementType.isRequired,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
   className: PropTypes.string,
 };
 

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -34,6 +34,7 @@ const CLICK_FEEDBACK_MS = 1200;
  */
 export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
+  const [isPending, setIsPending] = useState(false);
   const timeoutRef = useRef(null);
 
   useEffect(() => {
@@ -41,14 +42,22 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
   }, []);
 
   async function handleClick() {
-    const result = await onClick();
-    if (result) {
-      setJustSucceeded(true);
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(
-        () => setJustSucceeded(false),
-        CLICK_FEEDBACK_MS,
-      );
+    /* Guards against a rapid double-click firing onClick twice concurrently
+       (e.g. two overlapping PNG renders/downloads from the same button). */
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      const result = await onClick();
+      if (result) {
+        setJustSucceeded(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(
+          () => setJustSucceeded(false),
+          CLICK_FEEDBACK_MS,
+        );
+      }
+    } finally {
+      setIsPending(false);
     }
   }
 
@@ -56,8 +65,9 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
+      disabled={isPending}
       className={clsx(
-        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >
@@ -83,5 +93,32 @@ export function ShareButtonRow({ children }) {
 }
 
 ShareButtonRow.propTypes = {
+  children: PropTypes.node,
+};
+
+/**
+ * Wraps a ShareButtonRow so it's always visible when `show` is true (e.g. the
+ * latest chat message or chart), and otherwise hidden until the nearest
+ * ancestor with className="group" is hovered. Centralizes the opacity/hover
+ * treatment so chat messages and chart cards don't each hand-roll their own
+ * copy of the same `clsx` expression.
+ */
+export function HoverReveal({ show, className, children }) {
+  return (
+    <div
+      className={clsx(
+        'transition-opacity',
+        show ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+HoverReveal.propTypes = {
+  show: PropTypes.bool,
+  className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -12,6 +12,25 @@ const CLICK_FEEDBACK_MS = 1200;
  * chart cards. A full-scale "telescoping" widget (accepting multiple share
  * categories and expanding/collapsing between them) will be added here
  * later — this file is the single home for all shareability UI.
+ *
+ * @example
+ * import { ShareButton, ShareButtonRow } from './shareability';
+ * import { copyText, downloadCsv } from '../../../lib/shareActions';
+ * import { DocumentTextIcon, TableCellsIcon } from '@heroicons/react/24/outline';
+ *
+ * <ShareButtonRow>
+ *   <ShareButton
+ *     icon={DocumentTextIcon}
+ *     label="Copy text"
+ *     onClick={() => copyText(message.content)}
+ *   />
+ *   <ShareButton
+ *     icon={TableCellsIcon}
+ *     label="Download data as CSV"
+ *     onClick={() => downloadCsv(rows, 'chart.csv', headers)}
+ *     className="ml-2"
+ *   />
+ * </ShareButtonRow>
  */
 export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
@@ -37,9 +56,8 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
-      title={label}
       className={clsx(
-        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary text-paragraph-xs inline-flex items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
         className,
       )}
     >

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -65,9 +65,8 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
-      disabled={isPending}
       className={clsx(
-        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
         className,
       )}
     >

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { CheckIcon } from '@heroicons/react/24/outline';
+
+const CLICK_FEEDBACK_MS = 1200;
+
+/**
+ * shareability
+ *
+ * Hosts the lightweight ShareButton theme used inline in chat messages and
+ * chart cards. A full-scale "telescoping" widget (accepting multiple share
+ * categories and expanding/collapsing between them) will be added here
+ * later — this file is the single home for all shareability UI.
+ */
+export function ShareButton({ icon: Icon, label, onClick, disabled, className }) {
+  const [justSucceeded, setJustSucceeded] = useState(false);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  async function handleClick() {
+    const result = await onClick();
+    if (result) {
+      setJustSucceeded(true);
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(
+        () => setJustSucceeded(false),
+        CLICK_FEEDBACK_MS,
+      );
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      title={label}
+      className={clsx(
+        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-paragraph-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+    >
+      {justSucceeded ? (
+        <CheckIcon className="size-4" aria-hidden="true" />
+      ) : (
+        <Icon className="size-4" aria-hidden="true" />
+      )}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+ShareButton.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export function ShareButtonRow({ children }) {
+  return <div className="flex items-center gap-2">{children}</div>;
+}
+
+ShareButtonRow.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -10,15 +10,13 @@ import { toPng } from 'html-to-image';
  * widget without either pulling in React.
  */
 
-function triggerDownload(blob, filename) {
-  const url = URL.createObjectURL(blob);
+function triggerDownload(url, filename) {
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = filename;
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
 }
 
 export async function copyText(text) {
@@ -30,9 +28,9 @@ export async function copyText(text) {
   }
 }
 
-// Safari requires the Blobs passed to ClipboardItem be constructed
-// synchronously within the user-gesture call stack — don't `await` anything
-// before calling this from a click handler.
+/* Safari requires the Blobs passed to ClipboardItem be constructed
+   synchronously within the user-gesture call stack — don't `await` anything
+   before calling this from a click handler. */
 export async function copyRichText(html, plainTextFallback) {
   if (!window.ClipboardItem || !navigator.clipboard?.write) {
     return copyText(plainTextFallback);
@@ -63,7 +61,10 @@ export function downloadCsv(rows, filename, headers) {
     const csv = allRows
       .map((row) => row.map(escapeCsvCell).join(','))
       .join('\r\n');
-    triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
     return true;
   } catch {
     return false;
@@ -76,12 +77,7 @@ export async function downloadPng(node, filename) {
       backgroundColor: '#ffffff',
       pixelRatio: 2,
     });
-    const anchor = document.createElement('a');
-    anchor.href = dataUrl;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
+    triggerDownload(dataUrl, filename);
     return true;
   } catch {
     return false;

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -1,0 +1,69 @@
+/**
+ * shareActions
+ *
+ * Framework-agnostic functions invoked by ShareButton (see
+ * components/ui/molecule/shareability.jsx) when a user clicks a share/copy/
+ * download control. Kept separate from the UI so the same actions can be
+ * reused by both the lightweight ShareButton and the future telescoping
+ * widget without either pulling in React.
+ */
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Safari requires the Blobs passed to ClipboardItem be constructed
+// synchronously within the user-gesture call stack — don't `await` anything
+// before calling this from a click handler.
+export async function copyRichText(html, plainTextFallback) {
+  if (!window.ClipboardItem || !navigator.clipboard?.write) {
+    return copyText(plainTextFallback);
+  }
+
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([plainTextFallback], { type: 'text/plain' }),
+      }),
+    ]);
+    return true;
+  } catch {
+    return copyText(plainTextFallback);
+  }
+}
+
+function escapeCsvCell(cell) {
+  const value = cell ?? '';
+  const str = String(value);
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+export function downloadCsv(rows, filename, headers) {
+  try {
+    const allRows = headers ? [headers, ...rows] : rows;
+    const csv = allRows
+      .map((row) => row.map(escapeCsvCell).join(','))
+      .join('\r\n');
+    triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -1,3 +1,5 @@
+import { toPng } from 'html-to-image';
+
 /**
  * shareActions
  *
@@ -62,6 +64,24 @@ export function downloadCsv(rows, filename, headers) {
       .map((row) => row.map(escapeCsvCell).join(','))
       .join('\r\n');
     triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadPng(node, filename) {
+  try {
+    const dataUrl = await toPng(node, {
+      backgroundColor: '#ffffff',
+      pixelRatio: 2,
+    });
+    const anchor = document.createElement('a');
+    anchor.href = dataUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
     return true;
   } catch {
     return false;

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
+import clsx from 'clsx';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
@@ -14,6 +15,15 @@ import ResearchChart from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
+import { copyText, copyRichText } from '../lib/shareActions';
+import {
+  ShareButton,
+  ShareButtonRow,
+} from '../components/ui/molecule/shareability';
+import {
+  DocumentTextIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
@@ -76,9 +86,13 @@ export default function HeftiResearch() {
   const [charts, setCharts] = useState([]);
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
   const [chartsSpacerHeight, setChartsSpacerHeight] = useState(0);
+  const [isStreaming, setIsStreaming] = useState(false);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
   const chartsPanelRef = useRef(null);
+  // message.id -> rendered markdown DOM node, used to read rendered HTML for
+  // "copy as rich text" without keeping a ref per message via useRef.
+  const assistantContentRefs = useRef(new Map());
   // Mirrors lastUserMsgRef on the left: the first chart produced by the current
   // turn, which we pin to the top of the panel once it arrives.
   const turnFirstChartRef = useRef(null);
@@ -289,6 +303,7 @@ export default function HeftiResearch() {
 
     // console.log('[researcher] outgoing messages:', outgoingMessages);
 
+    setIsStreaming(true);
     try {
       const res = await fetch(`${API_BASE_URL}/researcher`, {
         method: 'POST',
@@ -364,6 +379,8 @@ export default function HeftiResearch() {
       });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsStreaming(false);
     }
   }
 
@@ -393,37 +410,87 @@ export default function HeftiResearch() {
                       const isLatestAssistant =
                         message.role === 'assistant' &&
                         i === messages.length - 1;
+                      const showShareRow =
+                        message.role === 'assistant' && !message.isError;
                       return (
-                        <div
-                          key={message.id}
-                          ref={isLastUser ? lastUserMsgRef : null}
-                          style={
-                            isLatestAssistant
-                              ? { minHeight: `${assistantMinHeight}px` }
-                              : undefined
-                          }
-                          className={
-                            message.role === 'user'
-                              ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
-                              : 'text-paragraph-base text-core-black max-w-[92%]'
-                          }
-                        >
-                          {message.role === 'assistant' ? (
-                            message.isError ? (
-                              <p className="text-paragraph-base text-red-600">
+                        <React.Fragment key={message.id}>
+                          <div
+                            ref={isLastUser ? lastUserMsgRef : null}
+                            style={
+                              isLatestAssistant
+                                ? { minHeight: `${assistantMinHeight}px` }
+                                : undefined
+                            }
+                            className={
+                              message.role === 'user'
+                                ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
+                                : 'peer text-paragraph-base text-core-black max-w-[92%]'
+                            }
+                          >
+                            {message.role === 'assistant' ? (
+                              message.isError ? (
+                                <p className="text-paragraph-base text-red-600">
+                                  {message.content}
+                                </p>
+                              ) : (
+                                <div
+                                  ref={(el) => {
+                                    if (el) {
+                                      assistantContentRefs.current.set(
+                                        message.id,
+                                        el,
+                                      );
+                                    } else {
+                                      assistantContentRefs.current.delete(
+                                        message.id,
+                                      );
+                                    }
+                                  }}
+                                >
+                                  <ReactMarkdown components={MdComponents}>
+                                    {message.content}
+                                  </ReactMarkdown>
+                                </div>
+                              )
+                            ) : (
+                              <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
                                 {message.content}
                               </p>
-                            ) : (
-                              <ReactMarkdown components={MdComponents}>
-                                {message.content}
-                              </ReactMarkdown>
-                            )
-                          ) : (
-                            <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
-                              {message.content}
-                            </p>
+                            )}
+                          </div>
+                          {showShareRow && (
+                            <div
+                              className={clsx(
+                                'mt-2! max-w-[92%] transition-opacity',
+                                isLatestAssistant
+                                  ? 'opacity-100'
+                                  : 'opacity-0 peer-hover:opacity-100',
+                              )}
+                            >
+                              <ShareButtonRow>
+                                <ShareButton
+                                  icon={DocumentTextIcon}
+                                  label="Copy text"
+                                  disabled={isLatestAssistant && isStreaming}
+                                  onClick={() => copyText(message.content)}
+                                />
+                                <ShareButton
+                                  icon={ClipboardDocumentIcon}
+                                  label="Copy as rich text"
+                                  disabled={isLatestAssistant && isStreaming}
+                                  onClick={() =>
+                                    copyRichText(
+                                      assistantContentRefs.current.get(
+                                        message.id,
+                                      )?.innerHTML ?? '',
+                                      message.content,
+                                    )
+                                  }
+                                />
+                              </ShareButtonRow>
+                            </div>
                           )}
-                        </div>
+                        </React.Fragment>
                       );
                     })}
                   </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -583,7 +583,10 @@ export default function HeftiResearch() {
                     i === turnStartIndexRef.current ? turnFirstChartRef : null
                   }
                 >
-                  <ResearchChart chart={chart} />
+                  <ResearchChart
+                    chart={chart}
+                    isLatest={i === charts.length - 1}
+                  />
                 </div>
                 {hasStarted && i === contextChartCountRef.current - 1 && (
                   <div className="flex items-center gap-3 py-2">

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
-import clsx from 'clsx';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
@@ -19,6 +18,7 @@ import { copyText, copyRichText } from '../lib/shareActions';
 import {
   ShareButton,
   ShareButtonRow,
+  HoverReveal,
 } from '../components/ui/molecule/shareability';
 import {
   DocumentTextIcon,
@@ -90,8 +90,8 @@ export default function HeftiResearch() {
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
   const chartsPanelRef = useRef(null);
-  // message.id -> rendered markdown DOM node, used to read rendered HTML for
-  // "copy as rich text" without keeping a ref per message via useRef.
+  /* message.id -> rendered markdown DOM node, used to read rendered HTML for
+     "copy as rich text" without keeping a ref per message via useRef. */
   const assistantContentRefs = useRef(new Map());
   // Mirrors lastUserMsgRef on the left: the first chart produced by the current
   // turn, which we pin to the top of the panel once it arrives.
@@ -413,7 +413,8 @@ export default function HeftiResearch() {
                       const showShareRow =
                         message.role === 'assistant' &&
                         !message.isError &&
-                        !(isLatestAssistant && isStreaming);
+                        !(isLatestAssistant && isStreaming) &&
+                        message.content.trim().length > 0;
                       return (
                         <div
                           key={message.id}
@@ -456,13 +457,9 @@ export default function HeftiResearch() {
                                   </ReactMarkdown>
                                 </div>
                                 {showShareRow && (
-                                  <div
-                                    className={clsx(
-                                      'mt-2 transition-opacity',
-                                      isLatestAssistant
-                                        ? 'opacity-100'
-                                        : 'opacity-0 group-hover:opacity-100',
-                                    )}
+                                  <HoverReveal
+                                    show={isLatestAssistant}
+                                    className="mt-2"
                                   >
                                     <ShareButtonRow>
                                       <ShareButton
@@ -485,7 +482,7 @@ export default function HeftiResearch() {
                                         }
                                       />
                                     </ShareButtonRow>
-                                  </div>
+                                  </HoverReveal>
                                 )}
                               </>
                             )
@@ -496,7 +493,7 @@ export default function HeftiResearch() {
                                   {message.content}
                                 </p>
                               </div>
-                              <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                              <HoverReveal className="mt-2 flex justify-end">
                                 <ShareButtonRow>
                                   <ShareButton
                                     icon={DocumentTextIcon}
@@ -504,7 +501,7 @@ export default function HeftiResearch() {
                                     onClick={() => copyText(message.content)}
                                   />
                                 </ShareButtonRow>
-                              </div>
+                              </HoverReveal>
                             </>
                           )}
                         </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -402,7 +402,7 @@ export default function HeftiResearch() {
                   ref={messagesContainerRef}
                   className="min-h-0 flex-1 overflow-y-auto px-6 py-8"
                 >
-                  <div className="space-y-5">
+                  <div className="space-y-2">
                     {messages.map((message, i) => {
                       const isLastUser =
                         message.role === 'user' &&
@@ -411,29 +411,33 @@ export default function HeftiResearch() {
                         message.role === 'assistant' &&
                         i === messages.length - 1;
                       const showShareRow =
-                        message.role === 'assistant' && !message.isError;
+                        message.role === 'assistant' &&
+                        !message.isError &&
+                        !(isLatestAssistant && isStreaming);
                       return (
-                        <React.Fragment key={message.id}>
-                          <div
-                            ref={isLastUser ? lastUserMsgRef : null}
-                            style={
-                              isLatestAssistant
-                                ? { minHeight: `${assistantMinHeight}px` }
-                                : undefined
-                            }
-                            className={
-                              message.role === 'user'
-                                ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
-                                : 'peer text-paragraph-base text-core-black max-w-[92%]'
-                            }
-                          >
-                            {message.role === 'assistant' ? (
-                              message.isError ? (
-                                <p className="text-paragraph-base text-red-600">
-                                  {message.content}
-                                </p>
-                              ) : (
+                        <div
+                          key={message.id}
+                          ref={isLastUser ? lastUserMsgRef : null}
+                          style={
+                            isLatestAssistant
+                              ? { minHeight: `${assistantMinHeight}px` }
+                              : undefined
+                          }
+                          className={
+                            message.role === 'user'
+                              ? 'group ml-auto max-w-[85%]'
+                              : 'group text-paragraph-base text-core-black max-w-[92%]'
+                          }
+                        >
+                          {message.role === 'assistant' ? (
+                            message.isError ? (
+                              <p className="text-paragraph-base text-red-600">
+                                {message.content}
+                              </p>
+                            ) : (
+                              <>
                                 <div
+                                  className="flow-root [&>*:last-child]:mb-0"
                                   ref={(el) => {
                                     if (el) {
                                       assistantContentRefs.current.set(
@@ -451,46 +455,59 @@ export default function HeftiResearch() {
                                     {message.content}
                                   </ReactMarkdown>
                                 </div>
-                              )
-                            ) : (
-                              <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
-                                {message.content}
-                              </p>
-                            )}
-                          </div>
-                          {showShareRow && (
-                            <div
-                              className={clsx(
-                                'mt-2! max-w-[92%] transition-opacity',
-                                isLatestAssistant
-                                  ? 'opacity-100'
-                                  : 'opacity-0 peer-hover:opacity-100',
-                              )}
-                            >
-                              <ShareButtonRow>
-                                <ShareButton
-                                  icon={DocumentTextIcon}
-                                  label="Copy text"
-                                  disabled={isLatestAssistant && isStreaming}
-                                  onClick={() => copyText(message.content)}
-                                />
-                                <ShareButton
-                                  icon={ClipboardDocumentIcon}
-                                  label="Copy as rich text"
-                                  disabled={isLatestAssistant && isStreaming}
-                                  onClick={() =>
-                                    copyRichText(
-                                      assistantContentRefs.current.get(
-                                        message.id,
-                                      )?.innerHTML ?? '',
-                                      message.content,
-                                    )
-                                  }
-                                />
-                              </ShareButtonRow>
-                            </div>
+                                {showShareRow && (
+                                  <div
+                                    className={clsx(
+                                      'mt-2 transition-opacity',
+                                      isLatestAssistant
+                                        ? 'opacity-100'
+                                        : 'opacity-0 group-hover:opacity-100',
+                                    )}
+                                  >
+                                    <ShareButtonRow>
+                                      <ShareButton
+                                        icon={DocumentTextIcon}
+                                        label="Copy text"
+                                        onClick={() =>
+                                          copyText(message.content)
+                                        }
+                                      />
+                                      <ShareButton
+                                        icon={ClipboardDocumentIcon}
+                                        label="Copy as rich text"
+                                        onClick={() =>
+                                          copyRichText(
+                                            assistantContentRefs.current.get(
+                                              message.id,
+                                            )?.innerHTML ?? '',
+                                            message.content,
+                                          )
+                                        }
+                                      />
+                                    </ShareButtonRow>
+                                  </div>
+                                )}
+                              </>
+                            )
+                          ) : (
+                            <>
+                              <div className="bg-background-primary rounded-3xl rounded-tr-sm px-4 py-3 text-left">
+                                <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
+                                  {message.content}
+                                </p>
+                              </div>
+                              <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                                <ShareButtonRow>
+                                  <ShareButton
+                                    icon={DocumentTextIcon}
+                                    label="Copy text"
+                                    onClick={() => copyText(message.content)}
+                                  />
+                                </ShareButtonRow>
+                              </div>
+                            </>
                           )}
-                        </React.Fragment>
+                        </div>
                       );
                     })}
                   </div>


### PR DESCRIPTION
- Adds the lightweight ShareButton/ShareButtonRow/HoverReveal theme (src/components/ui/molecule/shareability.jsx) and a dedicated src/lib/shareActions.js module hosting the actual copy/download logic — kept separate so a future full-scale "telescoping" widget theme can reuse the same functions.
- Chat messages: assistant responses get "Copy text" / "Copy as rich text" buttons (rich text preserves markdown formatting via the Clipboard API, with a plain-text fallback); user prompts get a "Copy text" button. Buttons are hidden while a response is streaming or has no text content, and reveal on hover for older messages while staying always-visible on the latest.
- Charts: each card gets "Download PNG" (via html-to-image) and "Download data as CSV" buttons, with a shared chartToRows/per-shape normalizer in ResearchChart.jsx so CSV export can't drift from what's rendered on screen.
- Hardening from review: guards against double-click firing an action twice, falls back to a generic filename when a chart title has no slugify-able characters, and dedupes the hover-reveal/anchor-download logic that was repeated across call sites.