### PR TITLE
Share global button (merge 2nd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+CLAUDE.local.md
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
         "html-to-image": "^1.11.13",
+        "jszip": "^3.10.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -4392,6 +4393,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6230,6 +6237,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -7079,6 +7092,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7111,6 +7136,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -8543,6 +8577,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8937,6 +8977,12 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9233,6 +9279,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -9569,6 +9636,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9674,6 +9747,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9987,6 +10066,15 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -10899,6 +10987,12 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "framer-motion": "^12.12.1",
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
+        "html-to-image": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -6193,6 +6194,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",
     "html-to-image": "^1.11.13",
+    "jszip": "^3.10.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^12.12.1",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",
+    "html-to-image": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/src/components/ui/atom/infoTooltip.jsx
+++ b/src/components/ui/atom/infoTooltip.jsx
@@ -1,6 +1,7 @@
 import { InformationCircleIcon } from '@heroicons/react/20/solid';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Tooltip from './tooltip';
 
 /**
  * Reusable Info Icon Tooltip
@@ -11,10 +12,9 @@ export default function InfoTooltip({ text }) {
   return (
     <div className="group relative flex items-center">
       <InformationCircleIcon className="h-5 w-5 text-zinc-400" />
-
-      <div className="pointer-events-none absolute top-1/2 left-6 z-50 hidden w-56 -translate-y-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+      <Tooltip position="right" className="w-56">
         {text}
-      </div>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/ui/atom/tooltip.jsx
+++ b/src/components/ui/atom/tooltip.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+
+const POSITION_CLASSES = {
+  top: 'bottom-full left-1/2 mb-2 -translate-x-1/2',
+  right: 'top-1/2 left-6 -translate-y-1/2',
+};
+
+const SIZE_CLASSES = {
+  xs: 'text-xs',
+  sm: 'text-paragraph-sm',
+};
+
+export default function Tooltip({
+  children,
+  className,
+  position = 'top',
+  size = 'xs',
+}) {
+  return (
+    <div
+      className={clsx(
+        'pointer-events-none absolute z-50 hidden w-max rounded-md bg-zinc-900 px-3 py-2 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100',
+        POSITION_CLASSES[position],
+        SIZE_CLASSES[size],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+Tooltip.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  position: PropTypes.oneOf(Object.keys(POSITION_CLASSES)),
+  size: PropTypes.oneOf(Object.keys(SIZE_CLASSES)),
+};

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -479,6 +479,22 @@ export function chartToRows(chart) {
   }
 }
 
+/* Combines every chart's rows into one CSV (one section per chart, separated
+   by a blank row), for the telescoping widget's "export everything in the
+   right panel" action. Each chart keeps its own title/headers since rows
+   from different chart_types rarely share the same columns. */
+export function combineChartsForExport(charts) {
+  const rows = [];
+  charts.forEach((chart, i) => {
+    if (i > 0) rows.push([]);
+    rows.push([chart.title]);
+    const { headers, rows: chartRows } = chartToRows(chart);
+    if (headers.length) rows.push(headers);
+    rows.push(...chartRows);
+  });
+  return rows;
+}
+
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -14,8 +14,10 @@ import {
 } from 'recharts';
 import { TableCellsIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { ShareButton, ShareButtonRow, HoverReveal } from './shareability';
-import { downloadCsv, downloadPng } from '../../../lib/shareActions';
-import { slugify } from '../../../lib/slugify';
+import {
+  downloadChartCsv,
+  downloadChartPng,
+} from '../../../lib/chartExport';
 
 /**
  * ResearchChart — chart rendering for the Hefti Researcher right panel.
@@ -109,18 +111,12 @@ function ChartWrapper({
   onCardMount,
 }) {
   const cardRef = useRef(null);
-  /* Falls back to a generic name when the title has no a-z0-9 characters for
-     slugify to keep (e.g. emoji/symbols-only), so the download isn't a bare
-     ".csv"/".png" with no visible filename. */
-  const filenameBase = slugify(title) || 'chart';
-
   function handleDownloadCsv() {
-    const { headers, rows } = chartToRows(chart);
-    return downloadCsv(rows, `${filenameBase}.csv`, headers);
+    return downloadChartCsv(chart, chartToRows);
   }
 
   function handleDownloadPng() {
-    return downloadPng(cardRef.current, `${filenameBase}.png`);
+    return downloadChartPng(cardRef.current, chart);
   }
 
   return (

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import {
   BarChart,
   Bar,
@@ -12,9 +13,9 @@ import {
   Scatter,
   ResponsiveContainer,
 } from 'recharts';
-import { TableCellsIcon } from '@heroicons/react/24/outline';
+import { TableCellsIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { ShareButton, ShareButtonRow } from './shareability';
-import { downloadCsv } from '../../../lib/shareActions';
+import { downloadCsv, downloadPng } from '../../../lib/shareActions';
 import { slugify } from '../../../lib/slugify';
 
 /**
@@ -100,15 +101,24 @@ ChartXTick.propTypes = {
 };
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
-function ChartWrapper({ title, description, children, chart }) {
+function ChartWrapper({ title, description, children, chart, isLatest }) {
+  const cardRef = useRef(null);
+
   function handleDownloadCsv() {
     const { headers, rows } = chartToRows(chart);
     return downloadCsv(rows, `${slugify(title)}.csv`, headers);
   }
 
+  function handleDownloadPng() {
+    return downloadPng(cardRef.current, `${slugify(title)}.png`);
+  }
+
   return (
-    <>
-      <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
+    <div className="group">
+      <div
+        ref={cardRef}
+        className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm"
+      >
         <p className="text-label-lg text-core-black">{title}</p>
         {description && (
           <p className="text-paragraph-base text-content-secondary mt-1">
@@ -117,8 +127,18 @@ function ChartWrapper({ title, description, children, chart }) {
         )}
         <div className="mt-4">{children}</div>
       </div>
-      <div className="mt-3">
+      <div
+        className={clsx(
+          'mt-3 transition-opacity',
+          isLatest ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        )}
+      >
         <ShareButtonRow>
+          <ShareButton
+            icon={PhotoIcon}
+            label="Download PNG"
+            onClick={handleDownloadPng}
+          />
           <ShareButton
             icon={TableCellsIcon}
             label="Download data as CSV"
@@ -126,13 +146,14 @@ function ChartWrapper({ title, description, children, chart }) {
           />
         </ShareButtonRow>
       </div>
-    </>
+    </div>
   );
 }
 
 ChartWrapper.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
+  isLatest: PropTypes.bool,
   chart: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 };
@@ -448,18 +469,24 @@ export function chartToRows(chart) {
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */
-export default function ResearchChart({ chart }) {
+export default function ResearchChart({ chart, isLatest }) {
   const { chart_type, title, description, data } = chart;
   const View = VIEWS[chart_type];
   if (!View) return null;
   return (
-    <ChartWrapper title={title} description={description} chart={chart}>
+    <ChartWrapper
+      title={title}
+      description={description}
+      chart={chart}
+      isLatest={isLatest}
+    >
       <View data={data} />
     </ChartWrapper>
   );
 }
 
 ResearchChart.propTypes = {
+  isLatest: PropTypes.bool,
   chart: PropTypes.shape({
     chart_type: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import {
   BarChart,
   Bar,
@@ -14,7 +13,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TableCellsIcon, PhotoIcon } from '@heroicons/react/24/outline';
-import { ShareButton, ShareButtonRow } from './shareability';
+import { ShareButton, ShareButtonRow, HoverReveal } from './shareability';
 import { downloadCsv, downloadPng } from '../../../lib/shareActions';
 import { slugify } from '../../../lib/slugify';
 
@@ -103,14 +102,18 @@ ChartXTick.propTypes = {
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
 function ChartWrapper({ title, description, children, chart, isLatest }) {
   const cardRef = useRef(null);
+  /* Falls back to a generic name when the title has no a-z0-9 characters for
+     slugify to keep (e.g. emoji/symbols-only), so the download isn't a bare
+     ".csv"/".png" with no visible filename. */
+  const filenameBase = slugify(title) || 'chart';
 
   function handleDownloadCsv() {
     const { headers, rows } = chartToRows(chart);
-    return downloadCsv(rows, `${slugify(title)}.csv`, headers);
+    return downloadCsv(rows, `${filenameBase}.csv`, headers);
   }
 
   function handleDownloadPng() {
-    return downloadPng(cardRef.current, `${slugify(title)}.png`);
+    return downloadPng(cardRef.current, `${filenameBase}.png`);
   }
 
   return (
@@ -127,12 +130,7 @@ function ChartWrapper({ title, description, children, chart, isLatest }) {
         )}
         <div className="mt-4">{children}</div>
       </div>
-      <div
-        className={clsx(
-          'mt-3 transition-opacity',
-          isLatest ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-        )}
-      >
+      <HoverReveal show={isLatest} className="mt-3">
         <ShareButtonRow>
           <ShareButton
             icon={PhotoIcon}
@@ -145,7 +143,7 @@ function ChartWrapper({ title, description, children, chart, isLatest }) {
             onClick={handleDownloadCsv}
           />
         </ShareButtonRow>
-      </div>
+      </HoverReveal>
     </div>
   );
 }
@@ -158,12 +156,42 @@ ChartWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-function BarView({ data }) {
-  const bars = data.bars ?? data.items ?? [];
-  const normalized = bars.map((b) => ({
-    label: b.label ?? b.name,
-    value: b.value,
+/* Shared shape-unwrapping helpers — used by both the View that renders a
+   chart_type and the matching case in chartToRows below, so the LLM's
+   field-naming fallbacks (e.g. `bars` vs `items`) only have to be encoded
+   once per chart_type instead of drifting between render and CSV export. */
+function normalizeBarItems(data) {
+  const items = data.bars ?? data.items ?? [];
+  return items.map((item) => ({
+    label: item.label ?? item.name,
+    value: item.value,
   }));
+}
+
+function normalizeDistributionItems(data) {
+  const items = data.bins ?? data.bars ?? data.items ?? [];
+  return items.map((item) => ({
+    label: item.range ?? item.label ?? item.name,
+    value: item.count ?? item.value,
+  }));
+}
+
+function seriesValueAt(series, i) {
+  return series.values?.[i] ?? series.data?.[i];
+}
+
+function normalizeTableShape(data) {
+  const rows = data.rows ?? [];
+  if (!rows.length) return { columns: [], rows: [], isArrayRows: false };
+  const isArrayRows = Array.isArray(rows[0]);
+  const columns = isArrayRows
+    ? (data.columns ?? rows[0].map((_, i) => String(i)))
+    : Object.keys(rows[0]);
+  return { columns, rows, isArrayRows };
+}
+
+function BarView({ data }) {
+  const normalized = normalizeBarItems(data);
   const { top, bottom } = xMargins(normalized.map((b) => b.label));
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -190,7 +218,7 @@ function ComparisonBarView({ data }) {
   const normalized = categories.map((cat, i) => {
     const row = { category: cat };
     series.forEach((s) => {
-      row[s.name] = s.values?.[i] ?? s.data?.[i];
+      row[s.name] = seriesValueAt(s, i);
     });
     return row;
   });
@@ -253,11 +281,7 @@ ScatterView.propTypes = {
 };
 
 function DistributionView({ data }) {
-  const bins = data.bins ?? data.bars ?? data.items ?? [];
-  const normalized = bins.map((b) => ({
-    label: b.range ?? b.label ?? b.name,
-    value: b.count ?? b.value,
-  }));
+  const normalized = normalizeDistributionItems(data);
   const { top, bottom } = xMargins(normalized.map((b) => b.label));
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -324,15 +348,8 @@ KpiRowView.propTypes = {
 };
 
 function TableView({ data }) {
-  const rows = data.rows ?? [];
+  const { columns, rows, isArrayRows } = normalizeTableShape(data);
   if (!rows.length) return null;
-
-  // rows can be array-of-arrays (with a separate columns array)
-  // or array-of-objects (columns derived from keys)
-  const isArrayRows = Array.isArray(rows[0]);
-  const columns = isArrayRows
-    ? (data.columns ?? rows[0].map((_, i) => String(i)))
-    : Object.keys(rows[0]);
 
   const getCell = (row, col, i) =>
     isArrayRows ? (row[i] ?? '—') : (row[col] ?? '—');
@@ -402,20 +419,17 @@ export function chartToRows(chart) {
 
   switch (chart_type) {
     case 'bar': {
-      const items = data.bars ?? data.items ?? [];
+      const items = normalizeBarItems(data);
       return {
         headers: ['Label', 'Value'],
-        rows: items.map((item) => [item.label ?? item.name, item.value]),
+        rows: items.map((item) => [item.label, item.value]),
       };
     }
     case 'distribution': {
-      const items = data.bins ?? data.bars ?? data.items ?? [];
+      const items = normalizeDistributionItems(data);
       return {
         headers: ['Label', 'Value'],
-        rows: items.map((item) => [
-          item.range ?? item.label ?? item.name,
-          item.count ?? item.value,
-        ]),
+        rows: items.map((item) => [item.label, item.value]),
       };
     }
     case 'comparison_bar': {
@@ -424,7 +438,7 @@ export function chartToRows(chart) {
         headers: ['Category', ...series.map((s) => s.name)],
         rows: categories.map((cat, i) => [
           cat,
-          ...series.map((s) => s.values?.[i] ?? s.data?.[i]),
+          ...series.map((s) => seriesValueAt(s, i)),
         ]),
       };
     }
@@ -448,12 +462,11 @@ export function chartToRows(chart) {
       };
     }
     case 'table': {
-      const rows = data.rows ?? [];
+      const { columns, rows, isArrayRows } = normalizeTableShape(data);
       if (!rows.length) return { headers: [], rows: [] };
-      const isArrayRows = Array.isArray(rows[0]);
-      const columns = isArrayRows
-        ? (data.columns ?? rows[0].map((_, i) => String(i)))
-        : Object.keys(rows[0]);
+      /* Empty string, not TableView's '—' placeholder — a literal em-dash in
+         an otherwise-numeric CSV column would be misread as text by Excel/
+         pandas instead of as a missing value. */
       const getCell = (row, col, i) =>
         isArrayRows ? (row[i] ?? '') : (row[col] ?? '');
       return {

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -12,6 +12,10 @@ import {
   Scatter,
   ResponsiveContainer,
 } from 'recharts';
+import { TableCellsIcon } from '@heroicons/react/24/outline';
+import { ShareButton, ShareButtonRow } from './shareability';
+import { downloadCsv } from '../../../lib/shareActions';
+import { slugify } from '../../../lib/slugify';
 
 /**
  * ResearchChart — chart rendering for the Hefti Researcher right panel.
@@ -96,7 +100,12 @@ ChartXTick.propTypes = {
 };
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
-function ChartWrapper({ title, description, children }) {
+function ChartWrapper({ title, description, children, chart }) {
+  function handleDownloadCsv() {
+    const { headers, rows } = chartToRows(chart);
+    return downloadCsv(rows, `${slugify(title)}.csv`, headers);
+  }
+
   return (
     <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
       <p className="text-label-lg text-core-black">{title}</p>
@@ -106,6 +115,15 @@ function ChartWrapper({ title, description, children }) {
         </p>
       )}
       <div className="mt-4">{children}</div>
+      <div className="mt-3">
+        <ShareButtonRow>
+          <ShareButton
+            icon={TableCellsIcon}
+            label="Download data as CSV"
+            onClick={handleDownloadCsv}
+          />
+        </ShareButtonRow>
+      </div>
     </div>
   );
 }
@@ -113,6 +131,7 @@ function ChartWrapper({ title, description, children }) {
 ChartWrapper.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
+  chart: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 };
 
@@ -351,6 +370,79 @@ const VIEWS = {
   table: TableView,
 };
 
+/* Converts a chart's `data` into flat { headers, rows } for CSV export,
+   reusing the same per-chart_type unwrap logic as the View components above.
+   Lives here (not in shareActions.js) since this file already owns the
+   chart_type-to-shape knowledge — shareActions.js stays generic. */
+export function chartToRows(chart) {
+  const { chart_type, data } = chart;
+
+  switch (chart_type) {
+    case 'bar': {
+      const items = data.bars ?? data.items ?? [];
+      return {
+        headers: ['Label', 'Value'],
+        rows: items.map((item) => [item.label ?? item.name, item.value]),
+      };
+    }
+    case 'distribution': {
+      const items = data.bins ?? data.bars ?? data.items ?? [];
+      return {
+        headers: ['Label', 'Value'],
+        rows: items.map((item) => [
+          item.range ?? item.label ?? item.name,
+          item.count ?? item.value,
+        ]),
+      };
+    }
+    case 'comparison_bar': {
+      const { categories = [], series = [] } = data;
+      return {
+        headers: ['Category', ...series.map((s) => s.name)],
+        rows: categories.map((cat, i) => [
+          cat,
+          ...series.map((s) => s.values?.[i] ?? s.data?.[i]),
+        ]),
+      };
+    }
+    case 'scatter': {
+      const points = data.points ?? [];
+      return {
+        headers: [data.xLabel ?? 'x', data.yLabel ?? 'y'],
+        rows: points.map((p) => [p.x, p.y]),
+      };
+    }
+    case 'kpi_row': {
+      const kpis = data.kpis ?? [];
+      return {
+        headers: ['Label', 'Value', 'Unit', 'Delta'],
+        rows: kpis.map((kpi) => [
+          kpi.label,
+          kpi.value,
+          kpi.unit ?? '',
+          kpi.delta ?? '',
+        ]),
+      };
+    }
+    case 'table': {
+      const rows = data.rows ?? [];
+      if (!rows.length) return { headers: [], rows: [] };
+      const isArrayRows = Array.isArray(rows[0]);
+      const columns = isArrayRows
+        ? (data.columns ?? rows[0].map((_, i) => String(i)))
+        : Object.keys(rows[0]);
+      const getCell = (row, col, i) =>
+        isArrayRows ? (row[i] ?? '') : (row[col] ?? '');
+      return {
+        headers: columns,
+        rows: rows.map((row) => columns.map((col, j) => getCell(row, col, j))),
+      };
+    }
+    default:
+      return { headers: [], rows: [] };
+  }
+}
+
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */
@@ -359,7 +451,7 @@ export default function ResearchChart({ chart }) {
   const View = VIEWS[chart_type];
   if (!View) return null;
   return (
-    <ChartWrapper title={title} description={description}>
+    <ChartWrapper title={title} description={description} chart={chart}>
       <View data={data} />
     </ChartWrapper>
   );

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -100,7 +100,14 @@ ChartXTick.propTypes = {
 };
 
 //The Recharts code lives inside the individual view components (BarView, ComparisonBarView, etc.) which get passed in as children. ChartWrapper just wraps them in the card with the border and title.
-function ChartWrapper({ title, description, children, chart, isLatest }) {
+function ChartWrapper({
+  title,
+  description,
+  children,
+  chart,
+  isLatest,
+  onCardMount,
+}) {
   const cardRef = useRef(null);
   /* Falls back to a generic name when the title has no a-z0-9 characters for
      slugify to keep (e.g. emoji/symbols-only), so the download isn't a bare
@@ -119,7 +126,10 @@ function ChartWrapper({ title, description, children, chart, isLatest }) {
   return (
     <div className="group">
       <div
-        ref={cardRef}
+        ref={(el) => {
+          cardRef.current = el;
+          onCardMount?.(el);
+        }}
         className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm"
       >
         <p className="text-label-lg text-core-black">{title}</p>
@@ -154,6 +164,7 @@ ChartWrapper.propTypes = {
   isLatest: PropTypes.bool,
   chart: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
+  onCardMount: PropTypes.func,
 };
 
 /* Shared shape-unwrapping helpers — used by both the View that renders a
@@ -479,26 +490,10 @@ export function chartToRows(chart) {
   }
 }
 
-/* Combines every chart's rows into one CSV (one section per chart, separated
-   by a blank row), for the telescoping widget's "export everything in the
-   right panel" action. Each chart keeps its own title/headers since rows
-   from different chart_types rarely share the same columns. */
-export function combineChartsForExport(charts) {
-  const rows = [];
-  charts.forEach((chart, i) => {
-    if (i > 0) rows.push([]);
-    rows.push([chart.title]);
-    const { headers, rows: chartRows } = chartToRows(chart);
-    if (headers.length) rows.push(headers);
-    rows.push(...chartRows);
-  });
-  return rows;
-}
-
 /* Entry point — receives a single chart object, looks up the right view from
    the VIEWS registry, and wraps it in ChartWrapper. Returns null for unknown
    chart types so unrecognized LLM output fails silently rather than crashing. */
-export default function ResearchChart({ chart, isLatest }) {
+export default function ResearchChart({ chart, isLatest, onCardMount }) {
   const { chart_type, title, description, data } = chart;
   const View = VIEWS[chart_type];
   if (!View) return null;
@@ -508,6 +503,7 @@ export default function ResearchChart({ chart, isLatest }) {
       description={description}
       chart={chart}
       isLatest={isLatest}
+      onCardMount={onCardMount}
     >
       <View data={data} />
     </ChartWrapper>
@@ -516,6 +512,7 @@ export default function ResearchChart({ chart, isLatest }) {
 
 ResearchChart.propTypes = {
   isLatest: PropTypes.bool,
+  onCardMount: PropTypes.func,
   chart: PropTypes.shape({
     chart_type: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/components/ui/molecule/ResearchChart.jsx
+++ b/src/components/ui/molecule/ResearchChart.jsx
@@ -107,14 +107,16 @@ function ChartWrapper({ title, description, children, chart }) {
   }
 
   return (
-    <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
-      <p className="text-label-lg text-core-black">{title}</p>
-      {description && (
-        <p className="text-paragraph-base text-content-secondary mt-1">
-          {description}
-        </p>
-      )}
-      <div className="mt-4">{children}</div>
+    <>
+      <div className="border-border-primary overflow-hidden rounded-lg border bg-white p-4 shadow-sm">
+        <p className="text-label-lg text-core-black">{title}</p>
+        {description && (
+          <p className="text-paragraph-base text-content-secondary mt-1">
+            {description}
+          </p>
+        )}
+        <div className="mt-4">{children}</div>
+      </div>
       <div className="mt-3">
         <ShareButtonRow>
           <ShareButton
@@ -124,7 +126,7 @@ function ChartWrapper({ title, description, children, chart }) {
           />
         </ShareButtonRow>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -13,7 +13,7 @@ const CLICK_FEEDBACK_MS = 1200;
  * categories and expanding/collapsing between them) will be added here
  * later — this file is the single home for all shareability UI.
  */
-export function ShareButton({ icon: Icon, label, onClick, disabled, className }) {
+export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
   const timeoutRef = useRef(null);
 
@@ -37,10 +37,9 @@ export function ShareButton({ icon: Icon, label, onClick, disabled, className })
     <button
       type="button"
       onClick={handleClick}
-      disabled={disabled}
       title={label}
       className={clsx(
-        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-paragraph-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary text-paragraph-xs inline-flex items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
         className,
       )}
     >
@@ -58,7 +57,6 @@ ShareButton.propTypes = {
   icon: PropTypes.elementType.isRequired,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
   className: PropTypes.string,
 };
 

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -153,7 +153,10 @@ function TelescopeSegment({
       if (result) {
         setStatus('success');
         clearTimeout(timeoutRef.current);
-        timeoutRef.current = setTimeout(() => setStatus('idle'), CLICK_FEEDBACK_MS);
+        timeoutRef.current = setTimeout(
+          () => setStatus('idle'),
+          CLICK_FEEDBACK_MS,
+        );
       } else {
         setStatus('idle');
       }
@@ -173,7 +176,7 @@ function TelescopeSegment({
       <button
         type="button"
         onClick={handleClick}
-        className="inline-flex cursor-pointer items-center gap-1.5 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-white/10"
+        className="text-paragraph-sm text-core-white inline-flex cursor-pointer items-center gap-1.5 px-3 py-2 transition-colors hover:bg-white/10"
       >
         <display.icon
           className={clsx('size-4', status === 'loading' && 'animate-spin')}
@@ -182,7 +185,7 @@ function TelescopeSegment({
         <span>{display.text}</span>
       </button>
       {tooltip && (
-        <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max max-w-56 -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+        <div className="text-core-white text-paragraph-sm pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max max-w-56 -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 opacity-0 shadow-sm transition-opacity duration-150 group-hover:block group-hover:opacity-100">
           {tooltip}
         </div>
       )}
@@ -221,7 +224,7 @@ TelescopeSegment.propTypes = {
 export function ShareWidget({
   categories,
   minimizedIcon: MinimizedIcon = ArrowDownTrayIcon,
-  minimizedLabel = 'Share',
+  minimizedLabel = 'Export',
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -232,11 +235,11 @@ export function ShareWidget({
           type="button"
           onClick={() => setIsExpanded(true)}
           aria-label={minimizedLabel}
-          className="inline-flex cursor-pointer items-center justify-center rounded-full bg-blue-600 p-2.5 text-white shadow-lg transition-colors hover:bg-blue-700"
+          className="text-core-white inline-flex cursor-pointer items-center justify-center rounded-md bg-blue-600 p-2.5 shadow-lg transition-colors hover:bg-blue-700"
         >
           <MinimizedIcon className="size-5" aria-hidden="true" />
         </button>
-        <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+        <div className="text-core-white pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
           {minimizedLabel}
         </div>
       </div>
@@ -244,7 +247,7 @@ export function ShareWidget({
   }
 
   return (
-    <div className="flex items-center divide-x divide-white/20 rounded-full bg-blue-600 text-white shadow-lg">
+    <div className="text-core-white flex items-center divide-x divide-white/20 rounded-md bg-blue-600 shadow-md">
       {categories.map((category) => (
         <TelescopeSegment key={category.label} {...category} />
       ))}

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -34,6 +34,7 @@ const CLICK_FEEDBACK_MS = 1200;
  */
 export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
+  const [isPending, setIsPending] = useState(false);
   const timeoutRef = useRef(null);
 
   useEffect(() => {
@@ -41,14 +42,22 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
   }, []);
 
   async function handleClick() {
-    const result = await onClick();
-    if (result) {
-      setJustSucceeded(true);
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(
-        () => setJustSucceeded(false),
-        CLICK_FEEDBACK_MS,
-      );
+    /* Guards against a rapid double-click firing onClick twice concurrently
+       (e.g. two overlapping PNG renders/downloads from the same button). */
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      const result = await onClick();
+      if (result) {
+        setJustSucceeded(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(
+          () => setJustSucceeded(false),
+          CLICK_FEEDBACK_MS,
+        );
+      }
+    } finally {
+      setIsPending(false);
     }
   }
 
@@ -56,8 +65,9 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
+      disabled={isPending}
       className={clsx(
-        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >
@@ -83,5 +93,32 @@ export function ShareButtonRow({ children }) {
 }
 
 ShareButtonRow.propTypes = {
+  children: PropTypes.node,
+};
+
+/**
+ * Wraps a ShareButtonRow so it's always visible when `show` is true (e.g. the
+ * latest chat message or chart), and otherwise hidden until the nearest
+ * ancestor with className="group" is hovered. Centralizes the opacity/hover
+ * treatment so chat messages and chart cards don't each hand-roll their own
+ * copy of the same `clsx` expression.
+ */
+export function HoverReveal({ show, className, children }) {
+  return (
+    <div
+      className={clsx(
+        'transition-opacity',
+        show ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+HoverReveal.propTypes = {
+  show: PropTypes.bool,
+  className: PropTypes.string,
   children: PropTypes.node,
 };

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -1,6 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { motion, AnimatePresence } from 'framer-motion';
 import {
   CheckIcon,
   ArrowPathIcon,
@@ -9,6 +15,60 @@ import {
 } from '@heroicons/react/24/outline';
 
 const CLICK_FEEDBACK_MS = 1200;
+const AUTO_COLLAPSE_MS = 2200;
+
+/* Animating `width` to/from the string 'auto' makes Framer Motion measure
+   the element's layout mid-animation, which is the source of a well-known
+   stutter partway through the transition. Measuring the content's actual
+   pixel width once up front and animating to/from that number instead
+   avoids the runtime auto-measurement entirely, so the transition is
+   driven purely by numbers with no layout reads competing with it. Each
+   segment grows/shrinks its own width rather than the whole bar fading as
+   one block — reads as the bar telescoping segments out of, and back into,
+   the persistent icon anchored at its right edge. */
+function GrowShrink({ className, children, skipEnter }) {
+  const contentRef = useRef(null);
+  const [contentWidth, setContentWidth] = useState(0);
+  const [settled, setSettled] = useState(false);
+
+  useLayoutEffect(() => {
+    if (contentRef.current) {
+      setContentWidth(contentRef.current.scrollWidth);
+    }
+  }, []);
+
+  /* Runs after paint, one render behind the layout effect above — lets the
+     very first width measurement (0 -> measured) render with skipFirstGrow
+     still true, before flipping settled for any later transitions. */
+  useEffect(() => {
+    if (contentWidth > 0) setSettled(true);
+  }, [contentWidth]);
+
+  const skipFirstGrow = skipEnter && !settled;
+
+  return (
+    <motion.div
+      initial={skipEnter ? false : { width: 0, opacity: 0 }}
+      animate={{
+        width: contentWidth,
+        opacity: 1,
+        transition: { duration: skipFirstGrow ? 0 : 0.2 },
+      }}
+      exit={{ width: 0, opacity: 0, transition: { duration: 0.6 } }}
+      className="overflow-x-hidden"
+    >
+      <div ref={contentRef} className={clsx('whitespace-nowrap', className)}>
+        {children}
+      </div>
+    </motion.div>
+  );
+}
+
+GrowShrink.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  skipEnter: PropTypes.bool,
+};
 
 /**
  * shareability
@@ -176,7 +236,7 @@ function TelescopeSegment({
       <button
         type="button"
         onClick={handleClick}
-        className="text-paragraph-sm text-core-white inline-flex cursor-pointer items-center gap-1.5 px-3 py-2 transition-colors hover:bg-white/10"
+        className="text-paragraph-sm text-core-white inline-flex cursor-pointer items-center gap-1.5 px-3 py-2 whitespace-nowrap transition-colors hover:bg-white/10"
       >
         <display.icon
           className={clsx('size-4', status === 'loading' && 'animate-spin')}
@@ -203,12 +263,20 @@ TelescopeSegment.propTypes = {
 };
 
 /**
- * ShareWidget — the full-scale telescoping theme. Minimized to a single icon
- * button; clicking it expands into a horizontal bar with one TelescopeSegment
- * per category (1-3) and a trailing close button that collapses it back.
+ * ShareWidget — the full-scale telescoping theme. A persistent icon button
+ * anchors the right edge; clicking it grows one TelescopeSegment per
+ * category (1-3) out to its left, each animating its own width in/out
+ * (rather than the whole bar fading as one block).
+ *
+ * When `title` is set, the widget mounts already expanded with that title
+ * grown in as a non-interactive leading label (a "display category") and
+ * the categories hidden, then auto-collapses on its own — a one-time
+ * introduction so a first-time viewer sees what the icon means before it
+ * withdraws back into the icon.
  *
  * @example
  * <ShareWidget
+ *   title="Export Session"
  *   categories={[
  *     {
  *       icon: TableCellsIcon,
@@ -223,42 +291,69 @@ TelescopeSegment.propTypes = {
  */
 export function ShareWidget({
   categories,
+  title,
   minimizedIcon: MinimizedIcon = ArrowDownTrayIcon,
   minimizedLabel = 'Export',
 }) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(Boolean(title));
+  const [isIntro, setIsIntro] = useState(Boolean(title));
+  const autoCollapseRef = useRef(null);
 
-  if (!isExpanded) {
-    return (
-      <div className="group relative flex items-center">
-        <button
-          type="button"
-          onClick={() => setIsExpanded(true)}
-          aria-label={minimizedLabel}
-          className="text-core-white inline-flex cursor-pointer items-center justify-center rounded-md bg-blue-600 p-2.5 shadow-lg transition-colors hover:bg-blue-700"
-        >
-          <MinimizedIcon className="size-5" aria-hidden="true" />
-        </button>
-        <div className="text-core-white pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
-          {minimizedLabel}
-        </div>
-      </div>
-    );
+  useEffect(() => {
+    if (!title) return;
+    autoCollapseRef.current = setTimeout(() => {
+      setIsExpanded(false);
+      setIsIntro(false);
+    }, AUTO_COLLAPSE_MS);
+    return () => clearTimeout(autoCollapseRef.current);
+  }, [title]);
+
+  function handleToggle(next) {
+    clearTimeout(autoCollapseRef.current);
+    setIsIntro(false);
+    setIsExpanded(next);
   }
 
   return (
     <div className="text-core-white flex items-center divide-x divide-white/20 rounded-md bg-blue-600 shadow-md">
-      {categories.map((category) => (
-        <TelescopeSegment key={category.label} {...category} />
-      ))}
-      <button
-        type="button"
-        onClick={() => setIsExpanded(false)}
-        aria-label="Close"
-        className="inline-flex cursor-pointer items-center px-3 py-2 transition-colors hover:bg-white/10"
-      >
-        <XMarkIcon className="size-4" aria-hidden="true" />
-      </button>
+      <AnimatePresence initial={false}>
+        {isExpanded && isIntro && (
+          <GrowShrink
+            key="title"
+            skipEnter
+            className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold"
+          >
+            <MinimizedIcon className="size-4" aria-hidden="true" />
+            {title}
+          </GrowShrink>
+        )}
+        {isExpanded &&
+          !isIntro &&
+          categories.map((category) => (
+            <GrowShrink key={category.label}>
+              <TelescopeSegment {...category} />
+            </GrowShrink>
+          ))}
+      </AnimatePresence>
+      <div className="group relative flex shrink-0 items-center">
+        <button
+          type="button"
+          onClick={() => handleToggle(!isExpanded)}
+          aria-label={isExpanded ? 'Close' : minimizedLabel}
+          className="inline-flex cursor-pointer items-center justify-center p-2.5 transition-colors hover:bg-white/10"
+        >
+          {isExpanded ? (
+            <XMarkIcon className="size-5" aria-hidden="true" />
+          ) : (
+            <MinimizedIcon className="size-5" aria-hidden="true" />
+          )}
+        </button>
+        {!isExpanded && (
+          <div className="text-core-white pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+            {minimizedLabel}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -274,6 +369,7 @@ ShareWidget.propTypes = {
       onClick: PropTypes.func.isRequired,
     }),
   ).isRequired,
+  title: PropTypes.string,
   minimizedIcon: PropTypes.elementType,
   minimizedLabel: PropTypes.string,
 };

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -12,6 +12,25 @@ const CLICK_FEEDBACK_MS = 1200;
  * chart cards. A full-scale "telescoping" widget (accepting multiple share
  * categories and expanding/collapsing between them) will be added here
  * later — this file is the single home for all shareability UI.
+ *
+ * @example
+ * import { ShareButton, ShareButtonRow } from './shareability';
+ * import { copyText, downloadCsv } from '../../../lib/shareActions';
+ * import { DocumentTextIcon, TableCellsIcon } from '@heroicons/react/24/outline';
+ *
+ * <ShareButtonRow>
+ *   <ShareButton
+ *     icon={DocumentTextIcon}
+ *     label="Copy text"
+ *     onClick={() => copyText(message.content)}
+ *   />
+ *   <ShareButton
+ *     icon={TableCellsIcon}
+ *     label="Download data as CSV"
+ *     onClick={() => downloadCsv(rows, 'chart.csv', headers)}
+ *     className="ml-2"
+ *   />
+ * </ShareButtonRow>
  */
 export function ShareButton({ icon: Icon, label, onClick, className }) {
   const [justSucceeded, setJustSucceeded] = useState(false);
@@ -37,9 +56,8 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
-      title={label}
       className={clsx(
-        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary text-paragraph-xs inline-flex items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
         className,
       )}
     >

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -13,6 +14,7 @@ import {
   XMarkIcon,
   ArrowDownTrayIcon,
 } from '@heroicons/react/24/outline';
+import Tooltip from '../atom/tooltip';
 
 const CLICK_FEEDBACK_MS = 1200;
 const AUTO_COLLAPSE_MS = 2200;
@@ -54,7 +56,15 @@ function GrowShrink({ className, children, skipEnter }) {
         opacity: 1,
         transition: { duration: skipFirstGrow ? 0 : 0.2 },
       }}
-      exit={{ width: 0, opacity: 0, transition: { duration: 0.6 } }}
+      /* pointerEvents isn't interpolated — Framer Motion applies it
+         immediately when exit starts, so a shrinking segment can't fire
+         hover/click while it's still visible mid-animation. */
+      exit={{
+        width: 0,
+        opacity: 0,
+        pointerEvents: 'none',
+        transition: { duration: 0.6 },
+      }}
       className="overflow-x-hidden"
     >
       <div ref={contentRef} className={clsx('whitespace-nowrap', className)}>
@@ -121,6 +131,10 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
           CLICK_FEEDBACK_MS,
         );
       }
+    } catch {
+      /* shareActions functions already resolve to false on failure rather
+         than throwing — this only guards against an unexpected rejection
+         becoming an unhandled promise rejection. */
     } finally {
       setIsPending(false);
     }
@@ -250,9 +264,9 @@ function TelescopeSegment({
         <span>{display.text}</span>
       </button>
       {tooltip && (
-        <div className="text-core-white text-paragraph-sm pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max max-w-56 -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 opacity-0 shadow-sm transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+        <Tooltip size="sm" className="max-w-56 shadow-sm">
           {tooltip}
-        </div>
+        </Tooltip>
       )}
     </div>
   );
@@ -305,16 +319,27 @@ export function ShareWidget({
   const [isExpanded, setIsExpanded] = useState(Boolean(title));
   const [isIntro, setIsIntro] = useState(Boolean(title));
   const autoCollapseRef = useRef(null);
+  const clearCategoryHover = useCallback(() => {
+    onCategoryHover?.(null);
+  }, [onCategoryHover]);
 
   useEffect(() => {
     if (!title) return;
     autoCollapseRef.current = setTimeout(() => {
       setIsExpanded(false);
       setIsIntro(false);
-      onCategoryHover?.(null);
+      clearCategoryHover();
     }, AUTO_COLLAPSE_MS);
     return () => clearTimeout(autoCollapseRef.current);
-  }, [title, onCategoryHover]);
+  }, [title, clearCategoryHover]);
+
+  useEffect(() => {
+    if (!isExpanded) clearCategoryHover();
+  }, [isExpanded, clearCategoryHover]);
+
+  useEffect(() => {
+    return clearCategoryHover;
+  }, [clearCategoryHover]);
 
   function handleToggle(next) {
     clearTimeout(autoCollapseRef.current);
@@ -322,11 +347,14 @@ export function ShareWidget({
     setIsExpanded(next);
     /* Collapsing unmounts the hovered segment without a mouseleave event,
        which would otherwise leave its highlight stuck on. */
-    if (!next) onCategoryHover?.(null);
+    if (!next) clearCategoryHover();
   }
 
   return (
-    <div className="text-core-white flex items-center divide-x divide-white/20 rounded-md bg-blue-600 shadow-md">
+    <div
+      className="text-core-white flex items-center divide-x divide-white/20 rounded-md bg-blue-600 shadow-md"
+      onMouseLeave={clearCategoryHover}
+    >
       <AnimatePresence initial={false}>
         {isExpanded && isIntro && (
           <GrowShrink
@@ -365,9 +393,9 @@ export function ShareWidget({
           )}
         </button>
         {!isExpanded && (
-          <div className="text-core-white pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+          <Tooltip>
             {minimizedLabel}
-          </div>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -65,9 +65,8 @@ export function ShareButton({ icon: Icon, label, onClick, className }) {
     <button
       type="button"
       onClick={handleClick}
-      disabled={isPending}
       className={clsx(
-        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50',
+        'border-border-primary text-content-secondary hover:bg-background-tertiary text-paragraph-xs hover:border-border-inverse-primary hover:text-border-inverse-primary inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors hover:shadow-sm',
         className,
       )}
     >

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { CheckIcon } from '@heroicons/react/24/outline';
+
+const CLICK_FEEDBACK_MS = 1200;
+
+/**
+ * shareability
+ *
+ * Hosts the lightweight ShareButton theme used inline in chat messages and
+ * chart cards. A full-scale "telescoping" widget (accepting multiple share
+ * categories and expanding/collapsing between them) will be added here
+ * later — this file is the single home for all shareability UI.
+ */
+export function ShareButton({ icon: Icon, label, onClick, disabled, className }) {
+  const [justSucceeded, setJustSucceeded] = useState(false);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  async function handleClick() {
+    const result = await onClick();
+    if (result) {
+      setJustSucceeded(true);
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(
+        () => setJustSucceeded(false),
+        CLICK_FEEDBACK_MS,
+      );
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      title={label}
+      className={clsx(
+        'border-border-primary bg-core-white text-content-secondary hover:bg-background-tertiary inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-paragraph-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+    >
+      {justSucceeded ? (
+        <CheckIcon className="size-4" aria-hidden="true" />
+      ) : (
+        <Icon className="size-4" aria-hidden="true" />
+      )}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+ShareButton.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export function ShareButtonRow({ children }) {
+  return <div className="flex items-center gap-2">{children}</div>;
+}
+
+ShareButtonRow.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { CheckIcon } from '@heroicons/react/24/outline';
+import {
+  CheckIcon,
+  ArrowPathIcon,
+  XMarkIcon,
+  ArrowDownTrayIcon,
+} from '@heroicons/react/24/outline';
 
 const CLICK_FEEDBACK_MS = 1200;
 
@@ -120,4 +125,152 @@ HoverReveal.propTypes = {
   show: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
+};
+
+/* One segment inside an expanded ShareWidget. Unlike ShareButton, the
+   in-flight state is visible (spinner + custom text) rather than a silent
+   guard, since the widget's segments need to show real export/copy progress. */
+function TelescopeSegment({
+  icon: Icon,
+  label,
+  tooltip,
+  loadingLabel,
+  successLabel,
+  onClick,
+}) {
+  const [status, setStatus] = useState('idle');
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  async function handleClick() {
+    if (status === 'loading') return;
+    setStatus('loading');
+    try {
+      const result = await onClick();
+      if (result) {
+        setStatus('success');
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setStatus('idle'), CLICK_FEEDBACK_MS);
+      } else {
+        setStatus('idle');
+      }
+    } catch {
+      setStatus('idle');
+    }
+  }
+
+  const display = {
+    idle: { icon: Icon, text: label },
+    loading: { icon: ArrowPathIcon, text: loadingLabel ?? label },
+    success: { icon: CheckIcon, text: successLabel ?? label },
+  }[status];
+
+  return (
+    <div className="group relative flex items-center">
+      <button
+        type="button"
+        onClick={handleClick}
+        className="inline-flex cursor-pointer items-center gap-1.5 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-white/10"
+      >
+        <display.icon
+          className={clsx('size-4', status === 'loading' && 'animate-spin')}
+          aria-hidden="true"
+        />
+        <span>{display.text}</span>
+      </button>
+      {tooltip && (
+        <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max max-w-56 -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+          {tooltip}
+        </div>
+      )}
+    </div>
+  );
+}
+
+TelescopeSegment.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  tooltip: PropTypes.string,
+  loadingLabel: PropTypes.string,
+  successLabel: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
+};
+
+/**
+ * ShareWidget — the full-scale telescoping theme. Minimized to a single icon
+ * button; clicking it expands into a horizontal bar with one TelescopeSegment
+ * per category (1-3) and a trailing close button that collapses it back.
+ *
+ * @example
+ * <ShareWidget
+ *   categories={[
+ *     {
+ *       icon: TableCellsIcon,
+ *       label: 'Right panel',
+ *       tooltip: 'Download charts + data',
+ *       loadingLabel: 'Exporting…',
+ *       successLabel: 'Downloaded',
+ *       onClick: () => downloadCsv(rows, 'charts.csv'),
+ *     },
+ *   ]}
+ * />
+ */
+export function ShareWidget({
+  categories,
+  minimizedIcon: MinimizedIcon = ArrowDownTrayIcon,
+  minimizedLabel = 'Share',
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!isExpanded) {
+    return (
+      <div className="group relative flex items-center">
+        <button
+          type="button"
+          onClick={() => setIsExpanded(true)}
+          aria-label={minimizedLabel}
+          className="inline-flex cursor-pointer items-center justify-center rounded-full bg-blue-600 p-2.5 text-white shadow-lg transition-colors hover:bg-blue-700"
+        >
+          <MinimizedIcon className="size-5" aria-hidden="true" />
+        </button>
+        <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-zinc-900 px-3 py-2 text-xs text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:block group-hover:opacity-100">
+          {minimizedLabel}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center divide-x divide-white/20 rounded-full bg-blue-600 text-white shadow-lg">
+      {categories.map((category) => (
+        <TelescopeSegment key={category.label} {...category} />
+      ))}
+      <button
+        type="button"
+        onClick={() => setIsExpanded(false)}
+        aria-label="Close"
+        className="inline-flex cursor-pointer items-center px-3 py-2 transition-colors hover:bg-white/10"
+      >
+        <XMarkIcon className="size-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+ShareWidget.propTypes = {
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.elementType.isRequired,
+      label: PropTypes.string.isRequired,
+      tooltip: PropTypes.string,
+      loadingLabel: PropTypes.string,
+      successLabel: PropTypes.string,
+      onClick: PropTypes.func.isRequired,
+    }),
+  ).isRequired,
+  minimizedIcon: PropTypes.elementType,
+  minimizedLabel: PropTypes.string,
 };

--- a/src/components/ui/molecule/shareability.jsx
+++ b/src/components/ui/molecule/shareability.jsx
@@ -197,6 +197,7 @@ function TelescopeSegment({
   loadingLabel,
   successLabel,
   onClick,
+  onHoverChange,
 }) {
   const [status, setStatus] = useState('idle');
   const timeoutRef = useRef(null);
@@ -232,7 +233,11 @@ function TelescopeSegment({
   }[status];
 
   return (
-    <div className="group relative flex items-center">
+    <div
+      className="group relative flex items-center"
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
+    >
       <button
         type="button"
         onClick={handleClick}
@@ -260,6 +265,7 @@ TelescopeSegment.propTypes = {
   loadingLabel: PropTypes.string,
   successLabel: PropTypes.string,
   onClick: PropTypes.func.isRequired,
+  onHoverChange: PropTypes.func,
 };
 
 /**
@@ -294,6 +300,7 @@ export function ShareWidget({
   title,
   minimizedIcon: MinimizedIcon = ArrowDownTrayIcon,
   minimizedLabel = 'Export',
+  onCategoryHover,
 }) {
   const [isExpanded, setIsExpanded] = useState(Boolean(title));
   const [isIntro, setIsIntro] = useState(Boolean(title));
@@ -304,14 +311,18 @@ export function ShareWidget({
     autoCollapseRef.current = setTimeout(() => {
       setIsExpanded(false);
       setIsIntro(false);
+      onCategoryHover?.(null);
     }, AUTO_COLLAPSE_MS);
     return () => clearTimeout(autoCollapseRef.current);
-  }, [title]);
+  }, [title, onCategoryHover]);
 
   function handleToggle(next) {
     clearTimeout(autoCollapseRef.current);
     setIsIntro(false);
     setIsExpanded(next);
+    /* Collapsing unmounts the hovered segment without a mouseleave event,
+       which would otherwise leave its highlight stuck on. */
+    if (!next) onCategoryHover?.(null);
   }
 
   return (
@@ -331,7 +342,12 @@ export function ShareWidget({
           !isIntro &&
           categories.map((category) => (
             <GrowShrink key={category.label}>
-              <TelescopeSegment {...category} />
+              <TelescopeSegment
+                {...category}
+                onHoverChange={(isHovering) =>
+                  onCategoryHover?.(isHovering ? category.target : null)
+                }
+              />
             </GrowShrink>
           ))}
       </AnimatePresence>
@@ -367,9 +383,13 @@ ShareWidget.propTypes = {
       loadingLabel: PropTypes.string,
       successLabel: PropTypes.string,
       onClick: PropTypes.func.isRequired,
+      /* Opaque identifier forwarded as-is to onCategoryHover — ShareWidget
+         doesn't interpret it, the caller defines what it means. */
+      target: PropTypes.string,
     }),
   ).isRequired,
   title: PropTypes.string,
   minimizedIcon: PropTypes.elementType,
   minimizedLabel: PropTypes.string,
+  onCategoryHover: PropTypes.func,
 };

--- a/src/lib/ResearchPanelDimOverlay.jsx
+++ b/src/lib/ResearchPanelDimOverlay.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import clsx from 'clsx';
+import { PANEL_DIM_OVERLAY_Z_CLASS } from './researchPanelAccent';
+
+export default function ResearchPanelDimOverlay() {
+  return (
+    <div
+      aria-hidden="true"
+      className={clsx(
+        'bg-core-white/70 pointer-events-none absolute inset-0 transition-opacity',
+        PANEL_DIM_OVERLAY_Z_CLASS,
+      )}
+    />
+  );
+}

--- a/src/lib/chartExport.js
+++ b/src/lib/chartExport.js
@@ -1,0 +1,41 @@
+import {
+  downloadCsv,
+  downloadPng,
+  nodeToPngDataUrl,
+  rowsToCsv,
+} from './shareActions';
+import { slugify } from './slugify';
+
+/* Falls back to a generic name when the title has no a-z0-9 characters for
+   slugify to keep (e.g. emoji/symbols-only), so downloads don't become a bare
+   ".csv"/".png" with no visible filename. */
+export function chartFilenameBase(chart, fallback = 'chart') {
+  return slugify(chart.title) || fallback;
+}
+
+export function chartCsvEntry(chart, chartToRows, fallbackName) {
+  const filenameBase = chartFilenameBase(chart, fallbackName);
+  const { headers, rows } = chartToRows(chart);
+  return {
+    name: `${filenameBase}.csv`,
+    content: rowsToCsv(rows, headers),
+  };
+}
+
+export async function chartPngEntry(node, chart, fallbackName) {
+  const filenameBase = chartFilenameBase(chart, fallbackName);
+  const dataUrl = await nodeToPngDataUrl(node);
+  return {
+    name: `${filenameBase}.png`,
+    content: dataUrl,
+  };
+}
+
+export function downloadChartCsv(chart, chartToRows) {
+  const { headers, rows } = chartToRows(chart);
+  return downloadCsv(rows, `${chartFilenameBase(chart)}.csv`, headers);
+}
+
+export function downloadChartPng(node, chart) {
+  return downloadPng(node, `${chartFilenameBase(chart)}.png`);
+}

--- a/src/lib/researchPanelAccent.js
+++ b/src/lib/researchPanelAccent.js
@@ -1,0 +1,35 @@
+export const SHARE_WIDGET_Z_CLASS = 'z-20';
+
+export const PANEL_DIM_OVERLAY_Z_CLASS = 'z-10';
+
+const EMPTY_PANEL_ACCENT = {
+  leftHighlighted: false,
+  rightHighlighted: false,
+  leftDimmed: false,
+  rightDimmed: false,
+};
+
+const PANEL_ACCENT_BY_TARGET = {
+  left: {
+    leftHighlighted: true,
+    rightHighlighted: false,
+    leftDimmed: false,
+    rightDimmed: true,
+  },
+  right: {
+    leftHighlighted: false,
+    rightHighlighted: true,
+    leftDimmed: true,
+    rightDimmed: false,
+  },
+  both: {
+    leftHighlighted: true,
+    rightHighlighted: true,
+    leftDimmed: false,
+    rightDimmed: false,
+  },
+};
+
+export function getPanelAccent(target) {
+  return PANEL_ACCENT_BY_TARGET[target] ?? EMPTY_PANEL_ACCENT;
+}

--- a/src/lib/researchShareActions.js
+++ b/src/lib/researchShareActions.js
@@ -1,0 +1,89 @@
+import { chartCsvEntry, chartPngEntry } from './chartExport';
+import { copyRichText, escapeHtml, downloadZip } from './shareActions';
+
+/* The telescoping widget's "Right panel" category: one PNG paired with one
+   CSV per chart, bundled into a single charts.zip. Skips the on-load context
+   charts; a chart that never mounted or whose PNG capture fails is skipped
+   entirely so the zip never has a CSV without its matching PNG. */
+async function exportRightPanel({
+  charts,
+  chartCardRefs,
+  chartToRows,
+  contextChartCountRef,
+}) {
+  const entries = [];
+  const startIndex = contextChartCountRef.current;
+
+  for (let i = startIndex; i < charts.length; i++) {
+    const node = chartCardRefs.current.get(i);
+    if (!node) continue;
+    const fallbackName = `chart-${i + 1}`;
+
+    try {
+      entries.push(await chartPngEntry(node, charts[i], fallbackName));
+    } catch {
+      continue;
+    }
+
+    entries.push(chartCsvEntry(charts[i], chartToRows, fallbackName));
+  }
+
+  if (entries.length === 0) return false;
+
+  return downloadZip(entries, 'charts.zip');
+}
+
+/* Copies the whole conversation as rich text, in order, so pasting into a
+   report/email keeps headers/bullets/etc. intact instead of dumping raw
+   markdown. User turns are escaped into HTML; assistant turns reuse their
+   already-rendered markdown HTML. */
+function copyLeftPanel({ messages, assistantContentRefs }) {
+  const turns = messages
+    .filter((m) => !m.isError && m.content.trim().length > 0)
+    .map((m) => {
+      const label = m.role === 'user' ? 'You' : 'Assistant';
+      const html =
+        m.role === 'user'
+          ? `<p>${escapeHtml(m.content).replace(/\n/g, '<br />')}</p>`
+          : (assistantContentRefs.current.get(m.id)?.innerHTML ?? '');
+      return { label, html, text: m.content };
+    });
+
+  const html = turns
+    .map((turn) => `<p><strong>${turn.label}:</strong></p>${turn.html}`)
+    .join('');
+  const text = turns.map((turn) => `${turn.label}:\n${turn.text}`).join('\n\n');
+
+  return copyRichText(html, text);
+}
+
+/* "Full session (PDF)" is wired up visually only; PDF export is a separate
+   follow-up. */
+async function exportFullSession() {
+  return false;
+}
+
+export function createResearchShareActions({
+  assistantContentRefs,
+  chartCardRefs,
+  charts,
+  chartToRows,
+  contextChartCountRef,
+  messages,
+}) {
+  return {
+    handleExportRightPanel: () =>
+      exportRightPanel({
+        charts,
+        chartCardRefs,
+        chartToRows,
+        contextChartCountRef,
+      }),
+    handleCopyLeftPanel: () =>
+      copyLeftPanel({
+        messages,
+        assistantContentRefs,
+      }),
+    handleExportFullSession: exportFullSession,
+  };
+}

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -10,15 +10,13 @@ import { toPng } from 'html-to-image';
  * widget without either pulling in React.
  */
 
-function triggerDownload(blob, filename) {
-  const url = URL.createObjectURL(blob);
+function triggerDownload(url, filename) {
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = filename;
   document.body.appendChild(anchor);
   anchor.click();
   document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
 }
 
 export async function copyText(text) {
@@ -30,9 +28,9 @@ export async function copyText(text) {
   }
 }
 
-// Safari requires the Blobs passed to ClipboardItem be constructed
-// synchronously within the user-gesture call stack — don't `await` anything
-// before calling this from a click handler.
+/* Safari requires the Blobs passed to ClipboardItem be constructed
+   synchronously within the user-gesture call stack — don't `await` anything
+   before calling this from a click handler. */
 export async function copyRichText(html, plainTextFallback) {
   if (!window.ClipboardItem || !navigator.clipboard?.write) {
     return copyText(plainTextFallback);
@@ -63,7 +61,10 @@ export function downloadCsv(rows, filename, headers) {
     const csv = allRows
       .map((row) => row.map(escapeCsvCell).join(','))
       .join('\r\n');
-    triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
     return true;
   } catch {
     return false;
@@ -76,12 +77,7 @@ export async function downloadPng(node, filename) {
       backgroundColor: '#ffffff',
       pixelRatio: 2,
     });
-    const anchor = document.createElement('a');
-    anchor.href = dataUrl;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
+    triggerDownload(dataUrl, filename);
     return true;
   } catch {
     return false;

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -57,7 +57,7 @@ export async function copyRichText(html, plainTextFallback) {
 function escapeCsvCell(cell) {
   const value = cell ?? '';
   const str = String(value);
-  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+  return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
 }
 
 export function rowsToCsv(rows, headers) {
@@ -72,7 +72,7 @@ export function downloadCsv(rows, filename, headers) {
     });
     const url = URL.createObjectURL(blob);
     triggerDownload(url, filename);
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
     return true;
   } catch {
     return false;
@@ -111,7 +111,7 @@ export async function downloadZip(entries, filename) {
     const blob = await zip.generateAsync({ type: 'blob' });
     const url = URL.createObjectURL(blob);
     triggerDownload(url, filename);
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
     return true;
   } catch {
     return false;

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -1,0 +1,69 @@
+/**
+ * shareActions
+ *
+ * Framework-agnostic functions invoked by ShareButton (see
+ * components/ui/molecule/shareability.jsx) when a user clicks a share/copy/
+ * download control. Kept separate from the UI so the same actions can be
+ * reused by both the lightweight ShareButton and the future telescoping
+ * widget without either pulling in React.
+ */
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Safari requires the Blobs passed to ClipboardItem be constructed
+// synchronously within the user-gesture call stack — don't `await` anything
+// before calling this from a click handler.
+export async function copyRichText(html, plainTextFallback) {
+  if (!window.ClipboardItem || !navigator.clipboard?.write) {
+    return copyText(plainTextFallback);
+  }
+
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([plainTextFallback], { type: 'text/plain' }),
+      }),
+    ]);
+    return true;
+  } catch {
+    return copyText(plainTextFallback);
+  }
+}
+
+function escapeCsvCell(cell) {
+  const value = cell ?? '';
+  const str = String(value);
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+export function downloadCsv(rows, filename, headers) {
+  try {
+    const allRows = headers ? [headers, ...rows] : rows;
+    const csv = allRows
+      .map((row) => row.map(escapeCsvCell).join(','))
+      .join('\r\n');
+    triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -71,11 +71,12 @@ export function downloadCsv(rows, filename, headers) {
   }
 }
 
-export async function downloadPng(node, filename) {
+export async function downloadPng(node, filename, options) {
   try {
     const dataUrl = await toPng(node, {
       backgroundColor: '#ffffff',
       pixelRatio: 2,
+      ...options,
     });
     triggerDownload(dataUrl, filename);
     return true;

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -75,13 +75,13 @@ export function downloadCsv(rows, filename, headers) {
   }
 }
 
-export function nodeToPngDataUrl(node, options) {
-  return toPng(node, { backgroundColor: '#ffffff', pixelRatio: 2, ...options });
+export function nodeToPngDataUrl(node) {
+  return toPng(node, { backgroundColor: '#ffffff', pixelRatio: 2 });
 }
 
-export async function downloadPng(node, filename, options) {
+export async function downloadPng(node, filename) {
   try {
-    const dataUrl = await nodeToPngDataUrl(node, options);
+    const dataUrl = await nodeToPngDataUrl(node);
     triggerDownload(dataUrl, filename);
     return true;
   } catch {

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -29,6 +29,10 @@ export async function copyText(text) {
   }
 }
 
+export function escapeHtml(text) {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 /* Safari requires the Blobs passed to ClipboardItem be constructed
    synchronously within the user-gesture call stack — don't `await` anything
    before calling this from a click handler. */

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -1,3 +1,5 @@
+import { toPng } from 'html-to-image';
+
 /**
  * shareActions
  *
@@ -62,6 +64,24 @@ export function downloadCsv(rows, filename, headers) {
       .map((row) => row.map(escapeCsvCell).join(','))
       .join('\r\n');
     triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadPng(node, filename) {
+  try {
+    const dataUrl = await toPng(node, {
+      backgroundColor: '#ffffff',
+      pixelRatio: 2,
+    });
+    const anchor = document.createElement('a');
+    anchor.href = dataUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
     return true;
   } catch {
     return false;

--- a/src/lib/shareActions.js
+++ b/src/lib/shareActions.js
@@ -1,4 +1,5 @@
 import { toPng } from 'html-to-image';
+import JSZip from 'jszip';
 
 /**
  * shareActions
@@ -55,13 +56,16 @@ function escapeCsvCell(cell) {
   return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
 }
 
+export function rowsToCsv(rows, headers) {
+  const allRows = headers ? [headers, ...rows] : rows;
+  return allRows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n');
+}
+
 export function downloadCsv(rows, filename, headers) {
   try {
-    const allRows = headers ? [headers, ...rows] : rows;
-    const csv = allRows
-      .map((row) => row.map(escapeCsvCell).join(','))
-      .join('\r\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const blob = new Blob([rowsToCsv(rows, headers)], {
+      type: 'text/csv;charset=utf-8;',
+    });
     const url = URL.createObjectURL(blob);
     triggerDownload(url, filename);
     URL.revokeObjectURL(url);
@@ -71,14 +75,39 @@ export function downloadCsv(rows, filename, headers) {
   }
 }
 
+export function nodeToPngDataUrl(node, options) {
+  return toPng(node, { backgroundColor: '#ffffff', pixelRatio: 2, ...options });
+}
+
 export async function downloadPng(node, filename, options) {
   try {
-    const dataUrl = await toPng(node, {
-      backgroundColor: '#ffffff',
-      pixelRatio: 2,
-      ...options,
-    });
+    const dataUrl = await nodeToPngDataUrl(node, options);
     triggerDownload(dataUrl, filename);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* entries: [{ name, content }], where content is either a plain string (CSV)
+   or a PNG data URL (from nodeToPngDataUrl) — used to bundle multiple
+   per-chart exports into one download instead of triggering N separate
+   downloads, which Chromium browsers block past the first couple in quick
+   succession. */
+export async function downloadZip(entries, filename) {
+  try {
+    const zip = new JSZip();
+    entries.forEach(({ name, content }) => {
+      if (content.startsWith('data:')) {
+        zip.file(name, content.split(',')[1], { base64: true });
+      } else {
+        zip.file(name, content);
+      }
+    });
+    const blob = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(url, filename);
+    URL.revokeObjectURL(url);
     return true;
   } catch {
     return false;

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
+import clsx from 'clsx';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
@@ -14,6 +15,15 @@ import ResearchChart from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
+import { copyText, copyRichText } from '../lib/shareActions';
+import {
+  ShareButton,
+  ShareButtonRow,
+} from '../components/ui/molecule/shareability';
+import {
+  DocumentTextIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline';
 
 const API_BASE_URL =
   import.meta.env.VITE_RESEARCHER_FUNCTION_URL ||
@@ -76,9 +86,13 @@ export default function HeftiResearch() {
   const [charts, setCharts] = useState([]);
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
   const [chartsSpacerHeight, setChartsSpacerHeight] = useState(0);
+  const [isStreaming, setIsStreaming] = useState(false);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
   const chartsPanelRef = useRef(null);
+  // message.id -> rendered markdown DOM node, used to read rendered HTML for
+  // "copy as rich text" without keeping a ref per message via useRef.
+  const assistantContentRefs = useRef(new Map());
   // Mirrors lastUserMsgRef on the left: the first chart produced by the current
   // turn, which we pin to the top of the panel once it arrives.
   const turnFirstChartRef = useRef(null);
@@ -289,6 +303,7 @@ export default function HeftiResearch() {
 
     // console.log('[researcher] outgoing messages:', outgoingMessages);
 
+    setIsStreaming(true);
     try {
       const res = await fetch(`${API_BASE_URL}/researcher`, {
         method: 'POST',
@@ -364,6 +379,8 @@ export default function HeftiResearch() {
       });
     } catch (err) {
       setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsStreaming(false);
     }
   }
 
@@ -393,37 +410,87 @@ export default function HeftiResearch() {
                       const isLatestAssistant =
                         message.role === 'assistant' &&
                         i === messages.length - 1;
+                      const showShareRow =
+                        message.role === 'assistant' && !message.isError;
                       return (
-                        <div
-                          key={message.id}
-                          ref={isLastUser ? lastUserMsgRef : null}
-                          style={
-                            isLatestAssistant
-                              ? { minHeight: `${assistantMinHeight}px` }
-                              : undefined
-                          }
-                          className={
-                            message.role === 'user'
-                              ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
-                              : 'text-paragraph-base text-core-black max-w-[92%]'
-                          }
-                        >
-                          {message.role === 'assistant' ? (
-                            message.isError ? (
-                              <p className="text-paragraph-base text-red-600">
+                        <React.Fragment key={message.id}>
+                          <div
+                            ref={isLastUser ? lastUserMsgRef : null}
+                            style={
+                              isLatestAssistant
+                                ? { minHeight: `${assistantMinHeight}px` }
+                                : undefined
+                            }
+                            className={
+                              message.role === 'user'
+                                ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
+                                : 'peer text-paragraph-base text-core-black max-w-[92%]'
+                            }
+                          >
+                            {message.role === 'assistant' ? (
+                              message.isError ? (
+                                <p className="text-paragraph-base text-red-600">
+                                  {message.content}
+                                </p>
+                              ) : (
+                                <div
+                                  ref={(el) => {
+                                    if (el) {
+                                      assistantContentRefs.current.set(
+                                        message.id,
+                                        el,
+                                      );
+                                    } else {
+                                      assistantContentRefs.current.delete(
+                                        message.id,
+                                      );
+                                    }
+                                  }}
+                                >
+                                  <ReactMarkdown components={MdComponents}>
+                                    {message.content}
+                                  </ReactMarkdown>
+                                </div>
+                              )
+                            ) : (
+                              <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
                                 {message.content}
                               </p>
-                            ) : (
-                              <ReactMarkdown components={MdComponents}>
-                                {message.content}
-                              </ReactMarkdown>
-                            )
-                          ) : (
-                            <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
-                              {message.content}
-                            </p>
+                            )}
+                          </div>
+                          {showShareRow && (
+                            <div
+                              className={clsx(
+                                'mt-2! max-w-[92%] transition-opacity',
+                                isLatestAssistant
+                                  ? 'opacity-100'
+                                  : 'opacity-0 peer-hover:opacity-100',
+                              )}
+                            >
+                              <ShareButtonRow>
+                                <ShareButton
+                                  icon={DocumentTextIcon}
+                                  label="Copy text"
+                                  disabled={isLatestAssistant && isStreaming}
+                                  onClick={() => copyText(message.content)}
+                                />
+                                <ShareButton
+                                  icon={ClipboardDocumentIcon}
+                                  label="Copy as rich text"
+                                  disabled={isLatestAssistant && isStreaming}
+                                  onClick={() =>
+                                    copyRichText(
+                                      assistantContentRefs.current.get(
+                                        message.id,
+                                      )?.innerHTML ?? '',
+                                      message.content,
+                                    )
+                                  }
+                                />
+                              </ShareButtonRow>
+                            </div>
                           )}
-                        </div>
+                        </React.Fragment>
                       );
                     })}
                   </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -583,7 +583,10 @@ export default function HeftiResearch() {
                     i === turnStartIndexRef.current ? turnFirstChartRef : null
                   }
                 >
-                  <ResearchChart chart={chart} />
+                  <ResearchChart
+                    chart={chart}
+                    isLatest={i === charts.length - 1}
+                  />
                 </div>
                 {hasStarted && i === contextChartCountRef.current - 1 && (
                   <div className="flex items-center gap-3 py-2">

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -580,7 +580,7 @@ export default function HeftiResearch() {
           className="bg-background-secondary relative flex min-h-0 flex-col"
         >
           {charts.length > 0 && (
-            <div className="absolute top-4 left-1/2 z-20 -translate-x-1/2">
+            <div className="absolute inset-x-0 top-4 z-20 mr-auto flex w-full max-w-[600px] justify-end px-6">
               <ShareWidget
                 categories={[
                   {

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -14,16 +14,14 @@ import { Heading } from '../components/ui/atom/heading';
 import ResearchChart, {
   chartToRows,
 } from '../components/ui/molecule/ResearchChart';
+import { chartCsvEntry, chartPngEntry } from '../lib/chartExport';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
-import { slugify } from '../lib/slugify';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
 import {
   copyText,
   copyRichText,
   escapeHtml,
-  rowsToCsv,
-  nodeToPngDataUrl,
   downloadZip,
 } from '../lib/shareActions';
 import {
@@ -49,6 +47,53 @@ const API_BASE_URL =
 const DATA_API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
+
+/* Panel accent stacking contract: dim overlays sit above panel content at
+   z-10, while the ShareWidget sits at z-20 so the active control remains
+   clickable and undimmed while it targets either panel. */
+const PANEL_DIM_OVERLAY_Z_CLASS = 'z-10';
+const SHARE_WIDGET_Z_CLASS = 'z-20';
+
+const EMPTY_PANEL_ACCENT = {
+  leftHighlighted: false,
+  rightHighlighted: false,
+  leftDimmed: false,
+  rightDimmed: false,
+};
+
+const PANEL_ACCENT_BY_TARGET = {
+  left: {
+    leftHighlighted: true,
+    rightHighlighted: false,
+    leftDimmed: false,
+    rightDimmed: true,
+  },
+  right: {
+    leftHighlighted: false,
+    rightHighlighted: true,
+    leftDimmed: true,
+    rightDimmed: false,
+  },
+  both: {
+    leftHighlighted: true,
+    rightHighlighted: true,
+    leftDimmed: false,
+    rightDimmed: false,
+  },
+};
+
+function DimOverlay() {
+  return (
+    <div
+      aria-hidden="true"
+      className={clsx(
+        'bg-core-white/70 pointer-events-none absolute inset-0 transition-opacity',
+        PANEL_DIM_OVERLAY_Z_CLASS,
+      )}
+    />
+  );
+}
+
 /**
  * HeftiResearch
  *
@@ -405,13 +450,14 @@ export default function HeftiResearch() {
     }
   }
 
-  /* The telescoping widget's "Right panel" category — one PNG and one CSV
-     per chart (PNG1, PNG2, PNG3, then CSV1, CSV2, CSV3), bundled into a
-     single charts.zip rather than triggering 2*N separate downloads (which
-     browsers throttle/block past ~2 rapid downloads from the same click).
-     Skips the on-load context charts (contextChartCountRef) — those are a
-     generic baseline comparison seeded before any prompt, not something the
-     user asked the AI for, so they don't belong in an export of its output. */
+  /* The telescoping widget's "Right panel" category — one PNG paired with
+     one CSV per chart, bundled into a single charts.zip. Skips the on-load context
+     charts (contextChartCountRef) — those are a generic baseline comparison
+     seeded before any prompt, not something the user asked the AI for, so
+     they don't belong in an export of its output. A chart that never
+     mounted (e.g. an unrecognized chart_type) or whose PNG capture fails
+     is skipped entirely, so the zip never ends up with a CSV that has no
+     matching PNG (or vice versa). */
   async function handleExportRightPanel() {
     const entries = [];
     const startIndex = contextChartCountRef.current;
@@ -419,19 +465,20 @@ export default function HeftiResearch() {
     for (let i = startIndex; i < charts.length; i++) {
       const node = chartCardRefs.current.get(i);
       if (!node) continue;
-      const filenameBase = slugify(charts[i].title) || `chart-${i + 1}`;
-      const dataUrl = await nodeToPngDataUrl(node);
-      entries.push({ name: `${filenameBase}.png`, content: dataUrl });
+      const fallbackName = `chart-${i + 1}`;
+
+      try {
+        entries.push(await chartPngEntry(node, charts[i], fallbackName));
+      } catch {
+        continue;
+      }
+
+      entries.push(chartCsvEntry(charts[i], chartToRows, fallbackName));
     }
 
-    charts.slice(startIndex).forEach((chart, i) => {
-      const filenameBase = slugify(chart.title) || `chart-${startIndex + i + 1}`;
-      const { headers, rows } = chartToRows(chart);
-      entries.push({
-        name: `${filenameBase}.csv`,
-        content: rowsToCsv(rows, headers),
-      });
-    });
+    // Nothing to export yet (e.g. clicked before any chart has streamed in)
+    // — a falsy return keeps the segment idle instead of flashing "Downloaded".
+    if (entries.length === 0) return false;
 
     return downloadZip(entries, 'charts.zip');
   }
@@ -472,10 +519,8 @@ export default function HeftiResearch() {
 
   // Drives the ShareWidget hover accent: the targeted panel(s) get a blue
   // highlight ring, the other panel gets dimmed by an overlay.
-  const isLeftHighlighted = hoveredTarget === 'left' || hoveredTarget === 'both';
-  const isRightHighlighted = hoveredTarget === 'right' || hoveredTarget === 'both';
-  const isLeftDimmed = hoveredTarget === 'right';
-  const isRightDimmed = hoveredTarget === 'left';
+  const { leftHighlighted, rightHighlighted, leftDimmed, rightDimmed } =
+    PANEL_ACCENT_BY_TARGET[hoveredTarget] ?? EMPTY_PANEL_ACCENT;
 
   return (
     <>
@@ -489,15 +534,10 @@ export default function HeftiResearch() {
         <section
           className={clsx(
             'bg-background-tertiary relative flex min-h-0 flex-col transition-shadow',
-            isLeftHighlighted && 'ring-2 ring-inset ring-blue-600',
+            leftHighlighted && 'ring-2 ring-blue-600 ring-inset',
           )}
         >
-          {isLeftDimmed && (
-            <div
-              aria-hidden="true"
-              className="bg-core-white/70 pointer-events-none absolute inset-0 z-10 transition-opacity"
-            />
-          )}
+          {leftDimmed && <DimOverlay />}
           <div className="ml-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
             {hasStarted ? (
               <>
@@ -665,19 +705,17 @@ export default function HeftiResearch() {
           aria-label="Generated charts"
           className={clsx(
             'bg-background-secondary relative flex min-h-0 flex-col transition-shadow',
-            isRightHighlighted && 'ring-2 ring-inset ring-blue-600',
+            rightHighlighted && 'ring-2 ring-blue-600 ring-inset',
           )}
         >
-          {isRightDimmed && (
-            /* z-10, below the widget's z-20 — dims the charts underneath
-               without dimming the widget the user is currently hovering. */
-            <div
-              aria-hidden="true"
-              className="bg-core-white/70 pointer-events-none absolute inset-0 z-10 transition-opacity"
-            />
-          )}
+          {rightDimmed && <DimOverlay />}
           {hasStarted && (
-            <div className="absolute inset-x-0 top-4 z-20 mr-auto flex w-full max-w-[600px] justify-end px-6">
+            <div
+              className={clsx(
+                'absolute inset-x-0 top-4 mr-auto flex w-full max-w-[600px] justify-end px-6',
+                SHARE_WIDGET_Z_CLASS,
+              )}
+            >
               <ShareWidget
                 title="Export Session"
                 onCategoryHover={setHoveredTarget}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -606,9 +606,10 @@ export default function HeftiResearch() {
           aria-label="Generated charts"
           className="bg-background-secondary relative flex min-h-0 flex-col"
         >
-          {charts.length > 0 && (
+          {hasStarted && (
             <div className="absolute inset-x-0 top-4 z-20 mr-auto flex w-full max-w-[600px] justify-end px-6">
               <ShareWidget
+                title="Export Session"
                 categories={[
                   {
                     icon: TableCellsIcon,

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -14,16 +14,16 @@ import { Heading } from '../components/ui/atom/heading';
 import ResearchChart, {
   chartToRows,
 } from '../components/ui/molecule/ResearchChart';
-import { chartCsvEntry, chartPngEntry } from '../lib/chartExport';
+import DimOverlay from '../lib/ResearchPanelDimOverlay';
+import {
+  getPanelAccent,
+  SHARE_WIDGET_Z_CLASS,
+} from '../lib/researchPanelAccent';
+import { createResearchShareActions } from '../lib/researchShareActions';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
-import {
-  copyText,
-  copyRichText,
-  escapeHtml,
-  downloadZip,
-} from '../lib/shareActions';
+import { copyText, copyRichText } from '../lib/shareActions';
 import {
   ShareButton,
   ShareButtonRow,
@@ -47,52 +47,6 @@ const API_BASE_URL =
 const DATA_API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   'http://hefti-data-api.ddev.site:3000/api';
-
-/* Panel accent stacking contract: dim overlays sit above panel content at
-   z-10, while the ShareWidget sits at z-20 so the active control remains
-   clickable and undimmed while it targets either panel. */
-const PANEL_DIM_OVERLAY_Z_CLASS = 'z-10';
-const SHARE_WIDGET_Z_CLASS = 'z-20';
-
-const EMPTY_PANEL_ACCENT = {
-  leftHighlighted: false,
-  rightHighlighted: false,
-  leftDimmed: false,
-  rightDimmed: false,
-};
-
-const PANEL_ACCENT_BY_TARGET = {
-  left: {
-    leftHighlighted: true,
-    rightHighlighted: false,
-    leftDimmed: false,
-    rightDimmed: true,
-  },
-  right: {
-    leftHighlighted: false,
-    rightHighlighted: true,
-    leftDimmed: true,
-    rightDimmed: false,
-  },
-  both: {
-    leftHighlighted: true,
-    rightHighlighted: true,
-    leftDimmed: false,
-    rightDimmed: false,
-  },
-};
-
-function DimOverlay() {
-  return (
-    <div
-      aria-hidden="true"
-      className={clsx(
-        'bg-core-white/70 pointer-events-none absolute inset-0 transition-opacity',
-        PANEL_DIM_OVERLAY_Z_CLASS,
-      )}
-    />
-  );
-}
 
 /**
  * HeftiResearch
@@ -450,77 +404,23 @@ export default function HeftiResearch() {
     }
   }
 
-  /* The telescoping widget's "Right panel" category — one PNG paired with
-     one CSV per chart, bundled into a single charts.zip. Skips the on-load context
-     charts (contextChartCountRef) — those are a generic baseline comparison
-     seeded before any prompt, not something the user asked the AI for, so
-     they don't belong in an export of its output. A chart that never
-     mounted (e.g. an unrecognized chart_type) or whose PNG capture fails
-     is skipped entirely, so the zip never ends up with a CSV that has no
-     matching PNG (or vice versa). */
-  async function handleExportRightPanel() {
-    const entries = [];
-    const startIndex = contextChartCountRef.current;
-
-    for (let i = startIndex; i < charts.length; i++) {
-      const node = chartCardRefs.current.get(i);
-      if (!node) continue;
-      const fallbackName = `chart-${i + 1}`;
-
-      try {
-        entries.push(await chartPngEntry(node, charts[i], fallbackName));
-      } catch {
-        continue;
-      }
-
-      entries.push(chartCsvEntry(charts[i], chartToRows, fallbackName));
-    }
-
-    // Nothing to export yet (e.g. clicked before any chart has streamed in)
-    // — a falsy return keeps the segment idle instead of flashing "Downloaded".
-    if (entries.length === 0) return false;
-
-    return downloadZip(entries, 'charts.zip');
-  }
-
-  /* "Left panel" — copies the whole conversation as rich text, in order, so
-     pasting into a report/email keeps headers/bullets/etc. intact instead of
-     dumping raw markdown. User turns are plain text escaped into HTML;
-     assistant turns reuse their already-rendered markdown HTML via
-     assistantContentRefs. Errors and empty turns are skipped (same rule
-     showShareRow uses for the per-message buttons). */
-  async function handleCopyLeftPanel() {
-    const turns = messages
-      .filter((m) => !m.isError && m.content.trim().length > 0)
-      .map((m) => {
-        const label = m.role === 'user' ? 'You' : 'Assistant';
-        const html =
-          m.role === 'user'
-            ? `<p>${escapeHtml(m.content).replace(/\n/g, '<br />')}</p>`
-            : (assistantContentRefs.current.get(m.id)?.innerHTML ?? '');
-        return { label, html, text: m.content };
-      });
-
-    const html = turns
-      .map((turn) => `<p><strong>${turn.label}:</strong></p>${turn.html}`)
-      .join('');
-    const text = turns
-      .map((turn) => `${turn.label}:\n${turn.text}`)
-      .join('\n\n');
-
-    return copyRichText(html, text);
-  }
-
-  /* "Full session (PDF)" is wired up visually only — PDF export is a
-     separate follow-up. */
-  async function handleExportFullSession() {
-    return false;
-  }
+  const {
+    handleExportRightPanel,
+    handleCopyLeftPanel,
+    handleExportFullSession,
+  } = createResearchShareActions({
+    assistantContentRefs,
+    chartCardRefs,
+    charts,
+    chartToRows,
+    contextChartCountRef,
+    messages,
+  });
 
   // Drives the ShareWidget hover accent: the targeted panel(s) get a blue
   // highlight ring, the other panel gets dimmed by an overlay.
   const { leftHighlighted, rightHighlighted, leftDimmed, rightDimmed } =
-    PANEL_ACCENT_BY_TARGET[hoveredTarget] ?? EMPTY_PANEL_ACCENT;
+    getPanelAccent(hoveredTarget);
 
   return (
     <>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -20,6 +20,7 @@ import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
 import {
   copyText,
   copyRichText,
+  escapeHtml,
   rowsToCsv,
   nodeToPngDataUrl,
   downloadZip,
@@ -33,7 +34,8 @@ import {
 import {
   DocumentTextIcon,
   ClipboardDocumentIcon,
-  TableCellsIcon,
+  ChartBarIcon,
+  DocumentArrowDownIcon,
 } from '@heroicons/react/24/outline';
 
 const API_BASE_URL =
@@ -429,6 +431,40 @@ export default function HeftiResearch() {
     return downloadZip(entries, 'charts.zip');
   }
 
+  /* "Left panel" — copies the whole conversation as rich text, in order, so
+     pasting into a report/email keeps headers/bullets/etc. intact instead of
+     dumping raw markdown. User turns are plain text escaped into HTML;
+     assistant turns reuse their already-rendered markdown HTML via
+     assistantContentRefs. Errors and empty turns are skipped (same rule
+     showShareRow uses for the per-message buttons). */
+  async function handleCopyLeftPanel() {
+    const turns = messages
+      .filter((m) => !m.isError && m.content.trim().length > 0)
+      .map((m) => {
+        const label = m.role === 'user' ? 'You' : 'Assistant';
+        const html =
+          m.role === 'user'
+            ? `<p>${escapeHtml(m.content).replace(/\n/g, '<br />')}</p>`
+            : (assistantContentRefs.current.get(m.id)?.innerHTML ?? '');
+        return { label, html, text: m.content };
+      });
+
+    const html = turns
+      .map((turn) => `<p><strong>${turn.label}:</strong></p>${turn.html}`)
+      .join('');
+    const text = turns
+      .map((turn) => `${turn.label}:\n${turn.text}`)
+      .join('\n\n');
+
+    return copyRichText(html, text);
+  }
+
+  /* "Full session (PDF)" is wired up visually only — PDF export is a
+     separate follow-up. */
+  async function handleExportFullSession() {
+    return false;
+  }
+
   return (
     <>
       <Breadcrumb pages={researchPages} />
@@ -612,7 +648,23 @@ export default function HeftiResearch() {
                 title="Export Session"
                 categories={[
                   {
-                    icon: TableCellsIcon,
+                    icon: ClipboardDocumentIcon,
+                    label: 'Left panel',
+                    tooltip: 'Copy all chat text',
+                    loadingLabel: 'Copying…',
+                    successLabel: 'Copied',
+                    onClick: handleCopyLeftPanel,
+                  },
+                  {
+                    icon: DocumentArrowDownIcon,
+                    label: 'Full session (PDF)',
+                    tooltip: 'Export the full session as a PDF',
+                    loadingLabel: 'Exporting…',
+                    successLabel: 'Downloaded',
+                    onClick: handleExportFullSession,
+                  },
+                  {
+                    icon: ChartBarIcon,
                     label: 'Right panel',
                     tooltip: 'Download charts + data',
                     loadingLabel: 'Exporting…',

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -11,12 +11,19 @@ import {
 } from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
 import ResearchChart, {
-  combineChartsForExport,
+  chartToRows,
 } from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
+import { slugify } from '../lib/slugify';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
-import { copyText, copyRichText, downloadCsv, downloadPng } from '../lib/shareActions';
+import {
+  copyText,
+  copyRichText,
+  rowsToCsv,
+  nodeToPngDataUrl,
+  downloadZip,
+} from '../lib/shareActions';
 import {
   ShareButton,
   ShareButtonRow,
@@ -97,6 +104,9 @@ export default function HeftiResearch() {
   /* message.id -> rendered markdown DOM node, used to read rendered HTML for
      "copy as rich text" without keeping a ref per message via useRef. */
   const assistantContentRefs = useRef(new Map());
+  /* chart index -> rendered card DOM node, used to capture each chart as its
+     own PNG for the "Right panel" export (see handleExportRightPanel). */
+  const chartCardRefs = useRef(new Map());
   // Mirrors lastUserMsgRef on the left: the first chart produced by the current
   // turn, which we pin to the top of the panel once it arrives.
   const turnFirstChartRef = useRef(null);
@@ -388,18 +398,35 @@ export default function HeftiResearch() {
     }
   }
 
-  /* The telescoping widget's "Right panel" category — combines every chart
-     into one CSV and one PNG of the whole panel, rather than triggering a
-     separate download per chart (which browsers throttle/block past ~2
-     rapid downloads from the same click). The trailing scroll spacer is
-     excluded from the PNG via data-export-ignore, since it's just empty
-     space reserved for scroll math, not visible content. */
+  /* The telescoping widget's "Right panel" category — one PNG and one CSV
+     per chart (PNG1, PNG2, PNG3, then CSV1, CSV2, CSV3), bundled into a
+     single charts.zip rather than triggering 2*N separate downloads (which
+     browsers throttle/block past ~2 rapid downloads from the same click).
+     Skips the on-load context charts (contextChartCountRef) — those are a
+     generic baseline comparison seeded before any prompt, not something the
+     user asked the AI for, so they don't belong in an export of its output. */
   async function handleExportRightPanel() {
-    const csvOk = downloadCsv(combineChartsForExport(charts), 'charts.csv');
-    const pngOk = await downloadPng(chartsPanelRef.current, 'charts.png', {
-      filter: (node) => node.dataset?.exportIgnore !== 'true',
+    const entries = [];
+    const startIndex = contextChartCountRef.current;
+
+    for (let i = startIndex; i < charts.length; i++) {
+      const node = chartCardRefs.current.get(i);
+      if (!node) continue;
+      const filenameBase = slugify(charts[i].title) || `chart-${i + 1}`;
+      const dataUrl = await nodeToPngDataUrl(node);
+      entries.push({ name: `${filenameBase}.png`, content: dataUrl });
+    }
+
+    charts.slice(startIndex).forEach((chart, i) => {
+      const filenameBase = slugify(chart.title) || `chart-${startIndex + i + 1}`;
+      const { headers, rows } = chartToRows(chart);
+      entries.push({
+        name: `${filenameBase}.csv`,
+        content: rowsToCsv(rows, headers),
+      });
     });
-    return csvOk && pngOk;
+
+    return downloadZip(entries, 'charts.zip');
   }
 
   return (
@@ -617,6 +644,13 @@ export default function HeftiResearch() {
                   <ResearchChart
                     chart={chart}
                     isLatest={i === charts.length - 1}
+                    onCardMount={(el) => {
+                      if (el) {
+                        chartCardRefs.current.set(i, el);
+                      } else {
+                        chartCardRefs.current.delete(i);
+                      }
+                    }}
                   />
                 </div>
                 {hasStarted && i === contextChartCountRef.current - 1 && (
@@ -643,7 +677,6 @@ export default function HeftiResearch() {
             {charts.length > 0 && (
               <div
                 aria-hidden="true"
-                data-export-ignore="true"
                 style={{ minHeight: `${chartsSpacerHeight}px` }}
               />
             )}

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
-import clsx from 'clsx';
 import { useParams, useLocation } from 'react-router-dom';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
@@ -19,6 +18,7 @@ import { copyText, copyRichText } from '../lib/shareActions';
 import {
   ShareButton,
   ShareButtonRow,
+  HoverReveal,
 } from '../components/ui/molecule/shareability';
 import {
   DocumentTextIcon,
@@ -90,8 +90,8 @@ export default function HeftiResearch() {
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
   const chartsPanelRef = useRef(null);
-  // message.id -> rendered markdown DOM node, used to read rendered HTML for
-  // "copy as rich text" without keeping a ref per message via useRef.
+  /* message.id -> rendered markdown DOM node, used to read rendered HTML for
+     "copy as rich text" without keeping a ref per message via useRef. */
   const assistantContentRefs = useRef(new Map());
   // Mirrors lastUserMsgRef on the left: the first chart produced by the current
   // turn, which we pin to the top of the panel once it arrives.
@@ -413,7 +413,8 @@ export default function HeftiResearch() {
                       const showShareRow =
                         message.role === 'assistant' &&
                         !message.isError &&
-                        !(isLatestAssistant && isStreaming);
+                        !(isLatestAssistant && isStreaming) &&
+                        message.content.trim().length > 0;
                       return (
                         <div
                           key={message.id}
@@ -456,13 +457,9 @@ export default function HeftiResearch() {
                                   </ReactMarkdown>
                                 </div>
                                 {showShareRow && (
-                                  <div
-                                    className={clsx(
-                                      'mt-2 transition-opacity',
-                                      isLatestAssistant
-                                        ? 'opacity-100'
-                                        : 'opacity-0 group-hover:opacity-100',
-                                    )}
+                                  <HoverReveal
+                                    show={isLatestAssistant}
+                                    className="mt-2"
                                   >
                                     <ShareButtonRow>
                                       <ShareButton
@@ -485,7 +482,7 @@ export default function HeftiResearch() {
                                         }
                                       />
                                     </ShareButtonRow>
-                                  </div>
+                                  </HoverReveal>
                                 )}
                               </>
                             )
@@ -496,7 +493,7 @@ export default function HeftiResearch() {
                                   {message.content}
                                 </p>
                               </div>
-                              <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                              <HoverReveal className="mt-2 flex justify-end">
                                 <ShareButtonRow>
                                   <ShareButton
                                     icon={DocumentTextIcon}
@@ -504,7 +501,7 @@ export default function HeftiResearch() {
                                     onClick={() => copyText(message.content)}
                                   />
                                 </ShareButtonRow>
-                              </div>
+                              </HoverReveal>
                             </>
                           )}
                         </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -402,7 +402,7 @@ export default function HeftiResearch() {
                   ref={messagesContainerRef}
                   className="min-h-0 flex-1 overflow-y-auto px-6 py-8"
                 >
-                  <div className="space-y-5">
+                  <div className="space-y-2">
                     {messages.map((message, i) => {
                       const isLastUser =
                         message.role === 'user' &&
@@ -411,29 +411,33 @@ export default function HeftiResearch() {
                         message.role === 'assistant' &&
                         i === messages.length - 1;
                       const showShareRow =
-                        message.role === 'assistant' && !message.isError;
+                        message.role === 'assistant' &&
+                        !message.isError &&
+                        !(isLatestAssistant && isStreaming);
                       return (
-                        <React.Fragment key={message.id}>
-                          <div
-                            ref={isLastUser ? lastUserMsgRef : null}
-                            style={
-                              isLatestAssistant
-                                ? { minHeight: `${assistantMinHeight}px` }
-                                : undefined
-                            }
-                            className={
-                              message.role === 'user'
-                                ? 'bg-background-primary ml-auto max-w-[85%] rounded-3xl rounded-tr-sm px-4 py-3 text-left'
-                                : 'peer text-paragraph-base text-core-black max-w-[92%]'
-                            }
-                          >
-                            {message.role === 'assistant' ? (
-                              message.isError ? (
-                                <p className="text-paragraph-base text-red-600">
-                                  {message.content}
-                                </p>
-                              ) : (
+                        <div
+                          key={message.id}
+                          ref={isLastUser ? lastUserMsgRef : null}
+                          style={
+                            isLatestAssistant
+                              ? { minHeight: `${assistantMinHeight}px` }
+                              : undefined
+                          }
+                          className={
+                            message.role === 'user'
+                              ? 'group ml-auto max-w-[85%]'
+                              : 'group text-paragraph-base text-core-black max-w-[92%]'
+                          }
+                        >
+                          {message.role === 'assistant' ? (
+                            message.isError ? (
+                              <p className="text-paragraph-base text-red-600">
+                                {message.content}
+                              </p>
+                            ) : (
+                              <>
                                 <div
+                                  className="flow-root [&>*:last-child]:mb-0"
                                   ref={(el) => {
                                     if (el) {
                                       assistantContentRefs.current.set(
@@ -451,46 +455,59 @@ export default function HeftiResearch() {
                                     {message.content}
                                   </ReactMarkdown>
                                 </div>
-                              )
-                            ) : (
-                              <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
-                                {message.content}
-                              </p>
-                            )}
-                          </div>
-                          {showShareRow && (
-                            <div
-                              className={clsx(
-                                'mt-2! max-w-[92%] transition-opacity',
-                                isLatestAssistant
-                                  ? 'opacity-100'
-                                  : 'opacity-0 peer-hover:opacity-100',
-                              )}
-                            >
-                              <ShareButtonRow>
-                                <ShareButton
-                                  icon={DocumentTextIcon}
-                                  label="Copy text"
-                                  disabled={isLatestAssistant && isStreaming}
-                                  onClick={() => copyText(message.content)}
-                                />
-                                <ShareButton
-                                  icon={ClipboardDocumentIcon}
-                                  label="Copy as rich text"
-                                  disabled={isLatestAssistant && isStreaming}
-                                  onClick={() =>
-                                    copyRichText(
-                                      assistantContentRefs.current.get(
-                                        message.id,
-                                      )?.innerHTML ?? '',
-                                      message.content,
-                                    )
-                                  }
-                                />
-                              </ShareButtonRow>
-                            </div>
+                                {showShareRow && (
+                                  <div
+                                    className={clsx(
+                                      'mt-2 transition-opacity',
+                                      isLatestAssistant
+                                        ? 'opacity-100'
+                                        : 'opacity-0 group-hover:opacity-100',
+                                    )}
+                                  >
+                                    <ShareButtonRow>
+                                      <ShareButton
+                                        icon={DocumentTextIcon}
+                                        label="Copy text"
+                                        onClick={() =>
+                                          copyText(message.content)
+                                        }
+                                      />
+                                      <ShareButton
+                                        icon={ClipboardDocumentIcon}
+                                        label="Copy as rich text"
+                                        onClick={() =>
+                                          copyRichText(
+                                            assistantContentRefs.current.get(
+                                              message.id,
+                                            )?.innerHTML ?? '',
+                                            message.content,
+                                          )
+                                        }
+                                      />
+                                    </ShareButtonRow>
+                                  </div>
+                                )}
+                              </>
+                            )
+                          ) : (
+                            <>
+                              <div className="bg-background-primary rounded-3xl rounded-tr-sm px-4 py-3 text-left">
+                                <p className="text-paragraph-base text-core-black wrap-break-word whitespace-pre-wrap">
+                                  {message.content}
+                                </p>
+                              </div>
+                              <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                                <ShareButtonRow>
+                                  <ShareButton
+                                    icon={DocumentTextIcon}
+                                    label="Copy text"
+                                    onClick={() => copyText(message.content)}
+                                  />
+                                </ShareButtonRow>
+                              </div>
+                            </>
                           )}
-                        </React.Fragment>
+                        </div>
                       );
                     })}
                   </div>

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useParams, useLocation } from 'react-router-dom';
+import clsx from 'clsx';
 import Breadcrumb from '../components/ui/molecule/breadcrumb';
 import ResearcherComposer from '../components/ui/molecule/researcherComposer';
 import ReactMarkdown from 'react-markdown';
@@ -100,6 +101,10 @@ export default function HeftiResearch() {
   const [assistantMinHeight, setAssistantMinHeight] = useState(0);
   const [chartsSpacerHeight, setChartsSpacerHeight] = useState(0);
   const [isStreaming, setIsStreaming] = useState(false);
+  /* Which panel(s) the ShareWidget's hovered segment targets ('left' |
+     'right' | 'both' | null) — drives the highlight/dim accent on the two
+     panels below. */
+  const [hoveredTarget, setHoveredTarget] = useState(null);
   const messagesContainerRef = useRef(null);
   const lastUserMsgRef = useRef(null);
   const chartsPanelRef = useRef(null);
@@ -465,6 +470,13 @@ export default function HeftiResearch() {
     return false;
   }
 
+  // Drives the ShareWidget hover accent: the targeted panel(s) get a blue
+  // highlight ring, the other panel gets dimmed by an overlay.
+  const isLeftHighlighted = hoveredTarget === 'left' || hoveredTarget === 'both';
+  const isRightHighlighted = hoveredTarget === 'right' || hoveredTarget === 'both';
+  const isLeftDimmed = hoveredTarget === 'right';
+  const isRightDimmed = hoveredTarget === 'left';
+
   return (
     <>
       <Breadcrumb pages={researchPages} />
@@ -474,7 +486,18 @@ export default function HeftiResearch() {
 
       <div className="bg-core-white grid h-[calc(100vh-140px)] grid-cols-1 lg:grid-cols-2">
         {/**Left-Panel Text and Input */}
-        <section className="bg-background-tertiary flex min-h-0 flex-col">
+        <section
+          className={clsx(
+            'bg-background-tertiary relative flex min-h-0 flex-col transition-shadow',
+            isLeftHighlighted && 'ring-2 ring-inset ring-blue-600',
+          )}
+        >
+          {isLeftDimmed && (
+            <div
+              aria-hidden="true"
+              className="bg-core-white/70 pointer-events-none absolute inset-0 z-10 transition-opacity"
+            />
+          )}
           <div className="ml-auto flex h-full min-h-0 w-full max-w-[640px] flex-col">
             {hasStarted ? (
               <>
@@ -640,12 +663,24 @@ export default function HeftiResearch() {
         {/* Right panel — chart output */}
         <section
           aria-label="Generated charts"
-          className="bg-background-secondary relative flex min-h-0 flex-col"
+          className={clsx(
+            'bg-background-secondary relative flex min-h-0 flex-col transition-shadow',
+            isRightHighlighted && 'ring-2 ring-inset ring-blue-600',
+          )}
         >
+          {isRightDimmed && (
+            /* z-10, below the widget's z-20 — dims the charts underneath
+               without dimming the widget the user is currently hovering. */
+            <div
+              aria-hidden="true"
+              className="bg-core-white/70 pointer-events-none absolute inset-0 z-10 transition-opacity"
+            />
+          )}
           {hasStarted && (
             <div className="absolute inset-x-0 top-4 z-20 mr-auto flex w-full max-w-[600px] justify-end px-6">
               <ShareWidget
                 title="Export Session"
+                onCategoryHover={setHoveredTarget}
                 categories={[
                   {
                     icon: ClipboardDocumentIcon,
@@ -654,6 +689,7 @@ export default function HeftiResearch() {
                     loadingLabel: 'Copying…',
                     successLabel: 'Copied',
                     onClick: handleCopyLeftPanel,
+                    target: 'left',
                   },
                   {
                     icon: DocumentArrowDownIcon,
@@ -662,6 +698,7 @@ export default function HeftiResearch() {
                     loadingLabel: 'Exporting…',
                     successLabel: 'Downloaded',
                     onClick: handleExportFullSession,
+                    target: 'both',
                   },
                   {
                     icon: ChartBarIcon,
@@ -670,6 +707,7 @@ export default function HeftiResearch() {
                     loadingLabel: 'Exporting…',
                     successLabel: 'Downloaded',
                     onClick: handleExportRightPanel,
+                    target: 'right',
                   },
                 ]}
               />

--- a/src/pages/HeftiResearch.jsx
+++ b/src/pages/HeftiResearch.jsx
@@ -10,19 +10,23 @@ import {
   getRankingsResearchPages,
 } from '../lib/breadcrumbPages';
 import { Heading } from '../components/ui/atom/heading';
-import ResearchChart from '../components/ui/molecule/ResearchChart';
+import ResearchChart, {
+  combineChartsForExport,
+} from '../components/ui/molecule/ResearchChart';
 import { buildContextCharts } from '../lib/contextChart';
 import { toTitleCase } from '../lib/toTitleCase';
 import { OWNER_PROMPTS, FACILITY_PROMPTS } from '../lib/researchPrompts';
-import { copyText, copyRichText } from '../lib/shareActions';
+import { copyText, copyRichText, downloadCsv, downloadPng } from '../lib/shareActions';
 import {
   ShareButton,
   ShareButtonRow,
   HoverReveal,
+  ShareWidget,
 } from '../components/ui/molecule/shareability';
 import {
   DocumentTextIcon,
   ClipboardDocumentIcon,
+  TableCellsIcon,
 } from '@heroicons/react/24/outline';
 
 const API_BASE_URL =
@@ -384,6 +388,20 @@ export default function HeftiResearch() {
     }
   }
 
+  /* The telescoping widget's "Right panel" category — combines every chart
+     into one CSV and one PNG of the whole panel, rather than triggering a
+     separate download per chart (which browsers throttle/block past ~2
+     rapid downloads from the same click). The trailing scroll spacer is
+     excluded from the PNG via data-export-ignore, since it's just empty
+     space reserved for scroll math, not visible content. */
+  async function handleExportRightPanel() {
+    const csvOk = downloadCsv(combineChartsForExport(charts), 'charts.csv');
+    const pngOk = await downloadPng(chartsPanelRef.current, 'charts.png', {
+      filter: (node) => node.dataset?.exportIgnore !== 'true',
+    });
+    return csvOk && pngOk;
+  }
+
   return (
     <>
       <Breadcrumb pages={researchPages} />
@@ -559,8 +577,24 @@ export default function HeftiResearch() {
         {/* Right panel — chart output */}
         <section
           aria-label="Generated charts"
-          className="bg-background-secondary flex min-h-0 flex-col"
+          className="bg-background-secondary relative flex min-h-0 flex-col"
         >
+          {charts.length > 0 && (
+            <div className="absolute top-4 left-1/2 z-20 -translate-x-1/2">
+              <ShareWidget
+                categories={[
+                  {
+                    icon: TableCellsIcon,
+                    label: 'Right panel',
+                    tooltip: 'Download charts + data',
+                    loadingLabel: 'Exporting…',
+                    successLabel: 'Downloaded',
+                    onClick: handleExportRightPanel,
+                  },
+                ]}
+              />
+            </div>
+          )}
           {/* aria-live announces newly streamed charts to screen readers, since
               they appear without any focus or navigation change. */}
           <div
@@ -609,6 +643,7 @@ export default function HeftiResearch() {
             {charts.length > 0 && (
               <div
                 aria-hidden="true"
+                data-export-ignore="true"
                 style={{ minHeight: `${chartsSpacerHeight}px` }}
               />
             )}


### PR DESCRIPTION
** Summary**

This PR adds the global share/export widget for the Hefti Researcher and wires up the share actions that belong to that widget. It also adds panel hover targeting so users can see which part of the Researcher will be affected by each export option, and extracts the supporting logic into small helper modules.


**What Changed**
- Added the telescoping ShareWidget UI for the Researcher.
- Wired global widget actions:copy the left-panel chat session as rich text/plain text fallback
- export right-panel generated charts and CSV data as a single charts.zip
- keep the full-session PDF option visually present as a no-op placeholder

- Added hover targeting for widget categories:highlight the targeted panel
1. dim the non-target panel
2. support left, right, and both-panel targets

- Hardened hover cleanup so panel highlight/dim state clears on collapse, auto-collapse, mouse leave, and unmount.
- Added shared chart export helpers for building ZIP entries from chart PNG + CSV pairs.
- Extracted Researcher-specific support logic into src/lib:researchShareActions
1.  researchPanelAccent
2.  ResearchPanelDimOverlay
3.  chartExport