### PR TITLE
feat: added CCN search to facilities browse page (Needs backend Pr #49)

### DIFF
--- a/src/components/ui/molecule/searchMenu.jsx
+++ b/src/components/ui/molecule/searchMenu.jsx
@@ -206,7 +206,9 @@ export default function SearchMenu({
         aria-expanded={showDropdown}
         aria-controls={showDropdown ? listboxId : undefined}
         aria-activedescendant={
-          activeSuggestion ? `${listboxId}-option-${activeSuggestion.id}` : undefined
+          activeSuggestion
+            ? `${listboxId}-option-${activeSuggestion.id}`
+            : undefined
         }
         aria-label={accessibleLabel}
         className="focus-ring-light text-paragraph-base text-core-black z-15 col-start-1 row-start-1 h-14 w-full appearance-none rounded-xl bg-white py-1.5 pr-8 pl-10 outline-1 -outline-offset-1 outline-gray-300 sm:text-sm/6"
@@ -294,8 +296,11 @@ export default function SearchMenu({
               &times;
             </button>
           </div>
-          <Heading id={mobileDialogTitleId} className="text-label-lg mb-2 font-bold">
-            Search by name
+          <Heading
+            id={mobileDialogTitleId}
+            className="text-label-lg mb-2 font-bold"
+          >
+            {accessibleLabel}
           </Heading>
           <div className="relative">
             <input
@@ -304,7 +309,9 @@ export default function SearchMenu({
               role="combobox"
               aria-autocomplete="list"
               aria-expanded={debouncedQuery !== ''}
-              aria-controls={debouncedQuery !== '' ? mobileListboxId : undefined}
+              aria-controls={
+                debouncedQuery !== '' ? mobileListboxId : undefined
+              }
               aria-activedescendant={
                 activeSuggestion
                   ? `${mobileListboxId}-option-${activeSuggestion.id}`

--- a/src/components/ui/organism/browseListView.jsx
+++ b/src/components/ui/organism/browseListView.jsx
@@ -17,6 +17,7 @@ import SearchMenu from '../molecule/searchMenu';
 export default function BrowseListView({
   title,
   children,
+  searchHeading = 'Search by name',
   searchPlaceholder,
   currentPage,
   totalPages,
@@ -52,13 +53,12 @@ export default function BrowseListView({
         {/*Search Bar */}
         <div className="py-8">
           <Heading id={searchHeadingId} level={2} className="text-label-lg">
-            {' '}
-            Search by name
+            {searchHeading}
           </Heading>
           <div className="flex flex-col items-center gap-2 md:flex-row md:items-center">
             <div className="w-full md:flex-[2]">
               <SearchMenu
-                accessibleLabel="Search by name"
+                accessibleLabel={searchHeading}
                 type={type}
                 placeholder={searchPlaceholder}
                 search={search}
@@ -130,6 +130,7 @@ export default function BrowseListView({
 BrowseListView.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node,
+  searchHeading: PropTypes.string,
   searchPlaceholder: PropTypes.string,
   search: PropTypes.string,
   currentPage: PropTypes.number.isRequired,

--- a/src/components/ui/organism/browsePage.jsx
+++ b/src/components/ui/organism/browsePage.jsx
@@ -37,6 +37,7 @@ export default function BrowsePage({
   apiEndpoint,
   suggestionsEndpoint,
   title,
+  searchHeading,
   searchPlaceholder,
   renderList,
   type,
@@ -171,6 +172,7 @@ export default function BrowsePage({
         suggestions={suggestions}
         hasFetchedSuggestions={hasFetchedSuggestions}
         title={title}
+        searchHeading={searchHeading}
         searchPlaceholder={searchPlaceholder}
         type={type}
         sortOptions={sortOptions}
@@ -205,6 +207,7 @@ BrowsePage.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,
   suggestionsEndpoint: PropTypes.string,
   title: PropTypes.string.isRequired,
+  searchHeading: PropTypes.string,
   searchPlaceholder: PropTypes.string,
   renderList: PropTypes.func.isRequired,
   type: PropTypes.oneOf(['facilities', 'owners', 'rankings']),

--- a/src/pages/Facilities.jsx
+++ b/src/pages/Facilities.jsx
@@ -72,7 +72,8 @@ function Facilities() {
       <BrowsePage
         apiEndpoint={`${API_BASE_URL}/facilities`}
         title="Nursing Homes"
-        searchPlaceholder="Nursing home name..."
+        searchHeading="Search by name or CCN"
+        searchPlaceholder="Nursing home name or CCN..."
         type="facilities"
         filterOptions={FACILITY_FILTER_OPTIONS}
         renderList={(items) => (


### PR DESCRIPTION
Created a prop that is passed at the (facility/owner) pages into the reusable search menu to allow the facility search to have the "Search by name and CCN" and the owner context to only have "Search by name"
