### PR TITLE
Homepage carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tailwindcss/vite": "^4.1.7",
         "clsx": "^2.1.1",
         "deps": "^1.0.0",
+        "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.12.1",
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
@@ -5148,6 +5149,35 @@
       "integrity": "sha512-rdmGfW47ZhL/oWEJAY4qxRtdly2B98ooTJ0pdEI4jhVLZ6tNf8fPtov2wS1IRKwFJT92le3x4Knxiwzl7cPPpQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tailwindcss/vite": "^4.1.7",
     "clsx": "^2.1.1",
     "deps": "^1.0.0",
+    "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.12.1",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",

--- a/src/components/ui/molecule/carousel.jsx
+++ b/src/components/ui/molecule/carousel.jsx
@@ -6,14 +6,43 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import { Heading } from '../atom/heading';
 import LayoutCard from '../atom/layout-card';
 
+/** Circular prev/next control. Positioning is supplied by `className` so the
+ *  same button works both in the desktop side gutters and, on mobile, inline
+ *  beside the dot tracker. */
+function CarouselArrow({ direction, onClick, className }) {
+  const Icon = direction === 'prev' ? ArrowLeftIcon : ArrowRightIcon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={direction === 'prev' ? 'Previous slide' : 'Next slide'}
+      className={clsx(
+        'focus-ring-light border-border-primary bg-core-white text-content-secondary hover:text-core-black flex size-10 items-center justify-center rounded-full border shadow-sm transition hover:cursor-pointer hover:shadow',
+        className,
+      )}
+    >
+      <Icon aria-hidden="true" className="size-5" />
+    </button>
+  );
+}
+
+CarouselArrow.propTypes = {
+  direction: PropTypes.oneOf(['prev', 'next']).isRequired,
+  onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
+
 /**
  * Carousel — a single white "container" that houses one slide at a time.
  *
  * Reflecting the trending-charts design, the container owns all the chrome:
- * the active slide's title/subtitle header, the prev/next arrows in the side
- * gutters, and the dot tracker along the bottom. Only the slide body (a chart,
- * a placeholder tile, …) swaps as the user flips through. The carousel loops,
- * so the arrows never disable at the ends.
+ * the active slide's title/subtitle header, the prev/next arrows, and the dot
+ * tracker along the bottom. Only the slide body (a chart, a placeholder tile,
+ * …) swaps as the user flips through. The carousel loops, so the arrows never
+ * disable at the ends.
+ *
+ * The arrows sit in the side gutters on desktop; on mobile (where those gutters
+ * are dropped to give the slide full width) they move inline to flank the dots.
  *
  * @example
  * <Carousel
@@ -49,15 +78,12 @@ export default function Carousel({ slides, options, ariaLabel }) {
 
   const activeSlide = slides[selectedIndex] ?? slides[0];
 
-  const arrowClasses =
-    'focus-ring-light absolute top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full border border-border-primary bg-core-white text-content-secondary shadow-sm transition hover:cursor-pointer hover:text-core-black hover:shadow';
-
   return (
     <LayoutCard>
       <div role="group" aria-roledescription="carousel" aria-label={ariaLabel}>
         {/* Same horizontal inset as the viewport below so the title/subtitle
             line up with the slide body rather than the arrow gutters. */}
-        <div className="mx-12 mb-4">
+        <div className="mb-4 md:mx-12">
           <Heading level={3} className="text-heading-xs">
             {activeSlide.title}
           </Heading>
@@ -69,7 +95,7 @@ export default function Carousel({ slides, options, ariaLabel }) {
         </div>
 
         <div className="relative">
-          <div className="mx-12 overflow-hidden" ref={emblaRef}>
+          <div className="overflow-hidden md:mx-12" ref={emblaRef}>
             <div className="flex">
               {slides.map((slide, index) => (
                 <div
@@ -87,41 +113,49 @@ export default function Carousel({ slides, options, ariaLabel }) {
             </div>
           </div>
 
-          <button
-            type="button"
+          {/* Desktop: arrows in the side gutters. */}
+          <CarouselArrow
+            direction="prev"
             onClick={scrollPrev}
-            aria-label="Previous slide"
-            className={clsx(arrowClasses, 'left-0')}
-          >
-            <ArrowLeftIcon aria-hidden="true" className="size-5" />
-          </button>
-          <button
-            type="button"
+            className="absolute top-1/2 left-0 z-10 hidden -translate-y-1/2 lg:flex"
+          />
+          <CarouselArrow
+            direction="next"
             onClick={scrollNext}
-            aria-label="Next slide"
-            className={clsx(arrowClasses, 'right-0')}
-          >
-            <ArrowRightIcon aria-hidden="true" className="size-5" />
-          </button>
+            className="absolute top-1/2 right-0 z-10 hidden -translate-y-1/2 lg:flex"
+          />
         </div>
 
-        <div className="mt-6 flex items-center justify-center gap-2.5">
-          {slides.map((_, index) => (
-            <button
-              /* Dots map one-to-one with the fixed slide list. */
-              key={index}
-              type="button"
-              onClick={() => scrollTo(index)}
-              aria-label={`Go to slide ${index + 1}`}
-              aria-current={index === selectedIndex ? 'true' : undefined}
-              className={clsx(
-                'focus-ring-light size-2.5 rounded-full transition hover:cursor-pointer',
-                index === selectedIndex
-                  ? 'bg-content-primary'
-                  : 'bg-border-primary hover:bg-content-tertiary',
-              )}
-            />
-          ))}
+        {/* Mobile: arrows flank the dots; desktop: dots only, centered. */}
+        <div className="mt-6 flex items-center justify-center gap-4">
+          <CarouselArrow
+            direction="prev"
+            onClick={scrollPrev}
+            className="lg:hidden"
+          />
+          <div className="flex items-center gap-2.5">
+            {slides.map((_, index) => (
+              <button
+                /* Dots map one-to-one with the fixed slide list. */
+                key={index}
+                type="button"
+                onClick={() => scrollTo(index)}
+                aria-label={`Go to slide ${index + 1}`}
+                aria-current={index === selectedIndex ? 'true' : undefined}
+                className={clsx(
+                  'focus-ring-light size-2.5 rounded-full transition hover:cursor-pointer',
+                  index === selectedIndex
+                    ? 'bg-content-primary'
+                    : 'bg-border-primary hover:bg-content-tertiary',
+                )}
+              />
+            ))}
+          </div>
+          <CarouselArrow
+            direction="next"
+            onClick={scrollNext}
+            className="lg:hidden"
+          />
         </div>
       </div>
     </LayoutCard>

--- a/src/components/ui/molecule/carousel.jsx
+++ b/src/components/ui/molecule/carousel.jsx
@@ -3,38 +3,39 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import useEmblaCarousel from 'embla-carousel-react';
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { Heading } from '../atom/heading';
+import LayoutCard from '../atom/layout-card';
 
 /**
- * Carousel — a generic, one-slide-per-view Embla carousel.
+ * Carousel — a single white "container" that houses one slide at a time.
  *
- * Renders each entry of `slides` as a full-width slide the user can flip
- * through with the prev/next arrows (positioned in the horizontal gutters to
- * either side of the slides) or the dot indicators below. Prev/next disable
- * themselves at the ends since the carousel does not loop by default.
- *
- * The component is deliberately presentation-agnostic: slides supply their own
- * cards/headings, so it can house real charts and placeholder tiles alike.
+ * Reflecting the trending-charts design, the container owns all the chrome:
+ * the active slide's title/subtitle header, the prev/next arrows in the side
+ * gutters, and the dot tracker along the bottom. Only the slide body (a chart,
+ * a placeholder tile, …) swaps as the user flips through. The carousel loops,
+ * so the arrows never disable at the ends.
  *
  * @example
  * <Carousel
  *   ariaLabel="Trending charts"
- *   slides={[<MyChart key="a" />, <Placeholder key="b" />]}
+ *   slides={[
+ *     { title: 'Ownership changes', subtitle: 'By month', content: <MyChart /> },
+ *   ]}
  * />
  */
 export default function Carousel({ slides, options, ariaLabel }) {
-  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false, ...options });
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, ...options });
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [canScrollPrev, setCanScrollPrev] = useState(false);
-  const [canScrollNext, setCanScrollNext] = useState(false);
 
   const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
   const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
-  const scrollTo = useCallback((index) => emblaApi?.scrollTo(index), [emblaApi]);
+  const scrollTo = useCallback(
+    (index) => emblaApi?.scrollTo(index),
+    [emblaApi],
+  );
 
   const onSelect = useCallback((api) => {
     setSelectedIndex(api.selectedScrollSnap());
-    setCanScrollPrev(api.canScrollPrev());
-    setCanScrollNext(api.canScrollNext());
   }, []);
 
   useEffect(() => {
@@ -46,78 +47,96 @@ export default function Carousel({ slides, options, ariaLabel }) {
     };
   }, [emblaApi, onSelect]);
 
+  const activeSlide = slides[selectedIndex] ?? slides[0];
+
   const arrowClasses =
-    'focus-ring-light absolute top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full border border-border-primary bg-core-white text-content-secondary shadow-sm transition hover:cursor-pointer hover:text-core-black hover:shadow disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none disabled:hover:text-content-secondary';
+    'focus-ring-light absolute top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full border border-border-primary bg-core-white text-content-secondary shadow-sm transition hover:cursor-pointer hover:text-core-black hover:shadow';
 
   return (
-    <div
-      className="relative px-6 sm:px-12"
-      role="group"
-      aria-roledescription="carousel"
-      aria-label={ariaLabel}
-    >
-      <div className="overflow-hidden" ref={emblaRef}>
-        <div className="flex">
-          {slides.map((slide, index) => (
-            <div
-              /* Slides are a fixed, caller-ordered list; index keys are stable. */
-              key={index}
-              className="min-w-0 flex-[0_0_100%] px-1"
-              role="group"
-              aria-roledescription="slide"
-              aria-label={`${index + 1} of ${slides.length}`}
-              aria-hidden={index !== selectedIndex}
-            >
-              {slide}
+    <LayoutCard>
+      <div role="group" aria-roledescription="carousel" aria-label={ariaLabel}>
+        {/* Same horizontal inset as the viewport below so the title/subtitle
+            line up with the slide body rather than the arrow gutters. */}
+        <div className="mx-12 mb-4">
+          <Heading level={3} className="text-heading-xs">
+            {activeSlide.title}
+          </Heading>
+          {activeSlide.subtitle && (
+            <p className="text-paragraph-sm text-content-secondary mt-1">
+              {activeSlide.subtitle}
+            </p>
+          )}
+        </div>
+
+        <div className="relative">
+          <div className="mx-12 overflow-hidden" ref={emblaRef}>
+            <div className="flex">
+              {slides.map((slide, index) => (
+                <div
+                  /* Slides are a fixed, caller-ordered list; index keys are stable. */
+                  key={index}
+                  className="min-w-0 flex-[0_0_100%]"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label={`${index + 1} of ${slides.length}`}
+                  aria-hidden={index !== selectedIndex}
+                >
+                  {slide.content}
+                </div>
+              ))}
             </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={scrollPrev}
+            aria-label="Previous slide"
+            className={clsx(arrowClasses, 'left-0')}
+          >
+            <ArrowLeftIcon aria-hidden="true" className="size-5" />
+          </button>
+          <button
+            type="button"
+            onClick={scrollNext}
+            aria-label="Next slide"
+            className={clsx(arrowClasses, 'right-0')}
+          >
+            <ArrowRightIcon aria-hidden="true" className="size-5" />
+          </button>
+        </div>
+
+        <div className="mt-6 flex items-center justify-center gap-2.5">
+          {slides.map((_, index) => (
+            <button
+              /* Dots map one-to-one with the fixed slide list. */
+              key={index}
+              type="button"
+              onClick={() => scrollTo(index)}
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={index === selectedIndex ? 'true' : undefined}
+              className={clsx(
+                'focus-ring-light size-2.5 rounded-full transition hover:cursor-pointer',
+                index === selectedIndex
+                  ? 'bg-content-primary'
+                  : 'bg-border-primary hover:bg-content-tertiary',
+              )}
+            />
           ))}
         </div>
       </div>
-
-      <button
-        type="button"
-        onClick={scrollPrev}
-        disabled={!canScrollPrev}
-        aria-label="Previous slide"
-        className={clsx(arrowClasses, 'left-0')}
-      >
-        <ArrowLeftIcon aria-hidden="true" className="size-5" />
-      </button>
-      <button
-        type="button"
-        onClick={scrollNext}
-        disabled={!canScrollNext}
-        aria-label="Next slide"
-        className={clsx(arrowClasses, 'right-0')}
-      >
-        <ArrowRightIcon aria-hidden="true" className="size-5" />
-      </button>
-
-      <div className="mt-6 flex items-center justify-center gap-2.5">
-        {slides.map((_, index) => (
-          <button
-            /* Dots map one-to-one with the fixed slide list. */
-            key={index}
-            type="button"
-            onClick={() => scrollTo(index)}
-            aria-label={`Go to slide ${index + 1}`}
-            aria-current={index === selectedIndex ? 'true' : undefined}
-            className={clsx(
-              'focus-ring-light size-2.5 rounded-full transition hover:cursor-pointer',
-              index === selectedIndex
-                ? 'bg-content-primary'
-                : 'bg-border-primary hover:bg-content-tertiary',
-            )}
-          />
-        ))}
-      </div>
-    </div>
+    </LayoutCard>
   );
 }
 
 Carousel.propTypes = {
-  slides: PropTypes.arrayOf(PropTypes.node).isRequired,
-  // Embla options object, merged over the { loop: false } default.
+  slides: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      subtitle: PropTypes.string,
+      content: PropTypes.node.isRequired,
+    }),
+  ).isRequired,
+  // Embla options object, merged over the { loop: true } default.
   options: PropTypes.object,
   ariaLabel: PropTypes.string,
 };

--- a/src/components/ui/molecule/carousel.jsx
+++ b/src/components/ui/molecule/carousel.jsx
@@ -76,6 +76,8 @@ export default function Carousel({ slides, options, ariaLabel }) {
     };
   }, [emblaApi, onSelect]);
 
+  if (!slides.length) return null;
+
   const activeSlide = slides[selectedIndex] ?? slides[0];
 
   return (
@@ -83,7 +85,7 @@ export default function Carousel({ slides, options, ariaLabel }) {
       <div role="group" aria-roledescription="carousel" aria-label={ariaLabel}>
         {/* Same horizontal inset as the viewport below so the title/subtitle
             line up with the slide body rather than the arrow gutters. */}
-        <div className="mb-4 md:mx-12">
+        <div className="mb-4 lg:mx-12">
           <Heading level={3} className="text-heading-xs">
             {activeSlide.title}
           </Heading>
@@ -95,7 +97,7 @@ export default function Carousel({ slides, options, ariaLabel }) {
         </div>
 
         <div className="relative">
-          <div className="overflow-hidden md:mx-12" ref={emblaRef}>
+          <div className="overflow-hidden lg:mx-12" ref={emblaRef}>
             <div className="flex">
               {slides.map((slide, index) => (
                 <div

--- a/src/components/ui/molecule/carousel.jsx
+++ b/src/components/ui/molecule/carousel.jsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import useEmblaCarousel from 'embla-carousel-react';
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+
+/**
+ * Carousel — a generic, one-slide-per-view Embla carousel.
+ *
+ * Renders each entry of `slides` as a full-width slide the user can flip
+ * through with the prev/next arrows (positioned in the horizontal gutters to
+ * either side of the slides) or the dot indicators below. Prev/next disable
+ * themselves at the ends since the carousel does not loop by default.
+ *
+ * The component is deliberately presentation-agnostic: slides supply their own
+ * cards/headings, so it can house real charts and placeholder tiles alike.
+ *
+ * @example
+ * <Carousel
+ *   ariaLabel="Trending charts"
+ *   slides={[<MyChart key="a" />, <Placeholder key="b" />]}
+ * />
+ */
+export default function Carousel({ slides, options, ariaLabel }) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false, ...options });
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+  const scrollTo = useCallback((index) => emblaApi?.scrollTo(index), [emblaApi]);
+
+  const onSelect = useCallback((api) => {
+    setSelectedIndex(api.selectedScrollSnap());
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return undefined;
+    onSelect(emblaApi);
+    emblaApi.on('select', onSelect).on('reInit', onSelect);
+    return () => {
+      emblaApi.off('select', onSelect).off('reInit', onSelect);
+    };
+  }, [emblaApi, onSelect]);
+
+  const arrowClasses =
+    'focus-ring-light absolute top-1/2 z-10 flex size-10 -translate-y-1/2 items-center justify-center rounded-full border border-border-primary bg-core-white text-content-secondary shadow-sm transition hover:cursor-pointer hover:text-core-black hover:shadow disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none disabled:hover:text-content-secondary';
+
+  return (
+    <div
+      className="relative px-6 sm:px-12"
+      role="group"
+      aria-roledescription="carousel"
+      aria-label={ariaLabel}
+    >
+      <div className="overflow-hidden" ref={emblaRef}>
+        <div className="flex">
+          {slides.map((slide, index) => (
+            <div
+              /* Slides are a fixed, caller-ordered list; index keys are stable. */
+              key={index}
+              className="min-w-0 flex-[0_0_100%] px-1"
+              role="group"
+              aria-roledescription="slide"
+              aria-label={`${index + 1} of ${slides.length}`}
+              aria-hidden={index !== selectedIndex}
+            >
+              {slide}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={scrollPrev}
+        disabled={!canScrollPrev}
+        aria-label="Previous slide"
+        className={clsx(arrowClasses, 'left-0')}
+      >
+        <ArrowLeftIcon aria-hidden="true" className="size-5" />
+      </button>
+      <button
+        type="button"
+        onClick={scrollNext}
+        disabled={!canScrollNext}
+        aria-label="Next slide"
+        className={clsx(arrowClasses, 'right-0')}
+      >
+        <ArrowRightIcon aria-hidden="true" className="size-5" />
+      </button>
+
+      <div className="mt-6 flex items-center justify-center gap-2.5">
+        {slides.map((_, index) => (
+          <button
+            /* Dots map one-to-one with the fixed slide list. */
+            key={index}
+            type="button"
+            onClick={() => scrollTo(index)}
+            aria-label={`Go to slide ${index + 1}`}
+            aria-current={index === selectedIndex ? 'true' : undefined}
+            className={clsx(
+              'focus-ring-light size-2.5 rounded-full transition hover:cursor-pointer',
+              index === selectedIndex
+                ? 'bg-content-primary'
+                : 'bg-border-primary hover:bg-content-tertiary',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+Carousel.propTypes = {
+  slides: PropTypes.arrayOf(PropTypes.node).isRequired,
+  // Embla options object, merged over the { loop: false } default.
+  options: PropTypes.object,
+  ariaLabel: PropTypes.string,
+};

--- a/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
+++ b/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
@@ -43,7 +43,7 @@ const dataItemShape = PropTypes.shape({
  * @param {{ value: string }} props.payload - Tick payload from Recharts (month string).
  * @param {Array<{month: string, count: number}>} props.data - Full chart dataset used to look up the count.
  * @param {number} props.axisWidth - Width of the Y-axis gutter, so the month
- *   label anchors to its left edge (varies between desktop and compact layouts).
+ *   label anchors to its left edge (varies between desktop and mobile layouts).
  */
 function CustomYAxisTick({ x, y, payload, data: chartData, axisWidth }) {
   const entry = chartData?.find((d) => d.month === payload.value);
@@ -124,7 +124,6 @@ PeakLowestLabel.propTypes = {
 /**
  * Accessible horizontal bar chart container. Wraps the Recharts BarChart with:
  * - A visually-hidden prose description (peak/lowest callouts).
- * - An aria-hidden visual column header row.
  * - A sr-only data table so screen readers can navigate individual values.
  *
  * @param {object} props

--- a/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
+++ b/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { ChartSkeleton } from '../atom/skeletons';
 import { ErrorBanner } from '../atom/errorBanner';
+import { useIsMobile } from '../../../hooks/useIsMobile';
 
 /**
  * @fileoverview Monthly SNF Ownership Change Volume chart.
@@ -21,6 +22,10 @@ import { ErrorBanner } from '../atom/errorBanner';
 
 const Y_AXIS_WIDTH = 130;
 const CHART_MARGIN = { top: 0, right: 120, bottom: 20, left: 10 };
+
+/* Mobile geometry for narrow cards below the md breakpoint we swap these in. */
+const MOBILE_Y_AXIS_WIDTH = 88;
+const MOBILE_CHART_MARGIN = { top: 0, right: 64, bottom: 20, left: 4 };
 
 const dataItemShape = PropTypes.shape({
   month: PropTypes.string.isRequired,
@@ -37,13 +42,15 @@ const dataItemShape = PropTypes.shape({
  * @param {number} props.y - SVG y coordinate provided by Recharts.
  * @param {{ value: string }} props.payload - Tick payload from Recharts (month string).
  * @param {Array<{month: string, count: number}>} props.data - Full chart dataset used to look up the count.
+ * @param {number} props.axisWidth - Width of the Y-axis gutter, so the month
+ *   label anchors to its left edge (varies between desktop and compact layouts).
  */
-function CustomYAxisTick({ x, y, payload, data: chartData }) {
+function CustomYAxisTick({ x, y, payload, data: chartData, axisWidth }) {
   const entry = chartData?.find((d) => d.month === payload.value);
   return (
     <g>
       <text
-        x={x - Y_AXIS_WIDTH + 5}
+        x={x - axisWidth + 5}
         y={y}
         textAnchor="start"
         dominantBaseline="middle"
@@ -73,6 +80,7 @@ CustomYAxisTick.propTypes = {
   y: PropTypes.number.isRequired,
   payload: PropTypes.shape({ value: PropTypes.string }).isRequired,
   data: PropTypes.arrayOf(dataItemShape).isRequired,
+  axisWidth: PropTypes.number.isRequired,
 };
 
 /**
@@ -125,6 +133,9 @@ PeakLowestLabel.propTypes = {
 function Chart({ data }) {
   const chartId = useId();
   const descId = `${chartId}-desc`;
+  const isMobile = useIsMobile(768);
+  const yAxisWidth = isMobile ? MOBILE_Y_AXIS_WIDTH : Y_AXIS_WIDTH;
+  const chartMargin = isMobile ? MOBILE_CHART_MARGIN : CHART_MARGIN;
   const peakMonth = data.find((d) => d.indicator === 'PEAK');
   const lowestMonth = data.find((d) => d.indicator === 'LOWEST');
 
@@ -144,22 +155,26 @@ function Chart({ data }) {
       <div
         role="img"
         aria-describedby={descId}
-        className="rounded-lg bg-gray-200 px-6 py-4"
+        className="rounded-lg bg-gray-200 px-3 py-4 md:px-6"
       >
         <ResponsiveContainer width="100%" height={580}>
           <BarChart
             layout="vertical"
             data={data}
-            margin={CHART_MARGIN}
+            margin={chartMargin}
             barCategoryGap="25%"
           >
             <XAxis type="number" hide domain={[0, 'dataMax']} />
             <YAxis
               type="category"
               dataKey="month"
-              width={Y_AXIS_WIDTH}
+              width={yAxisWidth}
               tick={(tickProps) => (
-                <CustomYAxisTick {...tickProps} data={data} />
+                <CustomYAxisTick
+                  {...tickProps}
+                  data={data}
+                  axisWidth={yAxisWidth}
+                />
               )}
               axisLine={false}
               tickLine={false}

--- a/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
+++ b/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
@@ -154,7 +154,7 @@ function Chart({ data }) {
       <div
         role="img"
         aria-describedby={descId}
-        className="rounded-lg bg-gray-200 px-3 py-4 md:px-6"
+        className="bg-background-primary rounded-lg px-3 py-4 md:px-6"
       >
         <ResponsiveContainer width="100%" height={580}>
           <BarChart

--- a/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
+++ b/src/components/ui/organism/monthlyOwnershipChangeChart.jsx
@@ -8,7 +8,6 @@ import {
   ResponsiveContainer,
   LabelList,
 } from 'recharts';
-import { Heading } from '../atom/heading';
 import { ChartSkeleton } from '../atom/skeletons';
 import { ErrorBanner } from '../atom/errorBanner';
 
@@ -130,7 +129,7 @@ function Chart({ data }) {
   const lowestMonth = data.find((d) => d.indicator === 'LOWEST');
 
   return (
-    <div className="bg-core-white border-border-primary overflow-hidden rounded-xl border p-4 shadow-sm sm:p-6">
+    <div className="overflow-hidden">
       <p id={descId} className="sr-only">
         Horizontal bar chart showing monthly counts of facilities with ownership
         changes in recent months.
@@ -142,15 +141,11 @@ function Chart({ data }) {
           : ''}
       </p>
 
-      {/* Column headers — widths mirror chart axis areas for alignment */}
-      <div aria-hidden="true" className="flex items-baseline border-b-[3px] border-black pb-1 text-sm font-semibold">
-        <div style={{ width: Y_AXIS_WIDTH, flexShrink: 0, paddingLeft: 5 }}>
-          Month
-        </div>
-        <div>Facilities with Ownership Changes</div>
-      </div>
-
-      <div role="img" aria-describedby={descId}>
+      <div
+        role="img"
+        aria-describedby={descId}
+        className="rounded-lg bg-gray-200 px-6 py-4"
+      >
         <ResponsiveContainer width="100%" height={580}>
           <BarChart
             layout="vertical"
@@ -219,7 +214,9 @@ Chart.propTypes = {
 /**
  * Top-level data-fetching component for the monthly ownership change chart.
  * Manages fetch lifecycle (loading / error / success) and renders the
- * appropriate state: skeleton, error banner, or the Chart.
+ * appropriate state: skeleton, error banner, or the Chart. Renders bare (no
+ * card chrome) so its container — the trending carousel — supplies the card and
+ * title.
  *
  * @returns {JSX.Element}
  */
@@ -227,7 +224,6 @@ export default function MonthlyOwnershipChangeChart() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const headingId = useId();
 
   const API_BASE_URL =
     import.meta.env.VITE_API_BASE_URL ??
@@ -262,31 +258,23 @@ export default function MonthlyOwnershipChangeChart() {
     return () => controller.abort();
   }, [API_BASE_URL]);
 
-  return (
-    <section aria-labelledby={headingId}>
-      <div>
-        <div className="mb-4">
-          <Heading id={headingId} level={3}>
-            Monthly SNF Ownership Change Volume
-          </Heading>
-        </div>
-
-        {loading ? (
-          <ChartSkeleton />
-        ) : error ? (
-          <>
-            <ErrorBanner
-              title="Chart data unavailable"
-              message="Ownership change data couldn't be fetched. Try refreshing the page."
-            />
-            <div className="pointer-events-none mt-4 opacity-60 select-none">
-              <ChartSkeleton error />
-            </div>
-          </>
-        ) : (
-          <Chart data={data} />
-        )}
+  const body = loading ? (
+    <ChartSkeleton />
+  ) : error ? (
+    <>
+      <ErrorBanner
+        title="Chart data unavailable"
+        message="Ownership change data couldn't be fetched. Try refreshing the page."
+      />
+      <div className="pointer-events-none mt-4 opacity-60 select-none">
+        <ChartSkeleton error />
       </div>
-    </section>
+    </>
+  ) : (
+    <Chart data={data} />
+  );
+
+  return (
+    <section aria-label="Monthly SNF ownership change volume">{body}</section>
   );
 }

--- a/src/components/ui/organism/trendingCarousel.jsx
+++ b/src/components/ui/organism/trendingCarousel.jsx
@@ -16,14 +16,17 @@ import MonthlyOwnershipChangeChart from './monthlyOwnershipChangeChart';
 /**
  * Empty chart area standing in for a trending chart that has not been built
  * yet. The carousel container renders its title/subtitle, so this is only the
- * body.
+ * body. Mirrors the real chart's gray-box wrapper (same padding + 580px plot
+ * height) so the card doesn't change height when flipping between slides.
  */
 function PlaceholderChart() {
   return (
     <div
-      className="bg-background-primary h-[580px] w-full rounded-lg"
+      className="bg-background-primary rounded-lg px-3 py-4 md:px-6"
       aria-hidden="true"
-    />
+    >
+      <div className="h-[580px] w-full" />
+    </div>
   );
 }
 

--- a/src/components/ui/organism/trendingCarousel.jsx
+++ b/src/components/ui/organism/trendingCarousel.jsx
@@ -1,5 +1,4 @@
 import React, { useId } from 'react';
-import PropTypes from 'prop-types';
 import { Heading } from '../atom/heading';
 import Carousel from '../molecule/carousel';
 import MonthlyOwnershipChangeChart from './monthlyOwnershipChangeChart';
@@ -7,51 +6,47 @@ import MonthlyOwnershipChangeChart from './monthlyOwnershipChangeChart';
 /**
  * @fileoverview "Trending in Nursing Home Data" home-page section.
  *
- * Houses the trending charts in an Embla carousel. Today only one real chart
- * exists (MonthlyOwnershipChangeChart); the remaining slides are placeholder
- * tiles so the carousel is navigable until more charts are built.
+ * Houses the trending charts in a single Embla carousel container. The
+ * container supplies the title/subtitle, arrows, and dot tracker; each slide
+ * only provides the body that swaps inside it. Today one real chart exists
+ * (MonthlyOwnershipChangeChart, rendered bare via its `embedded` mode); the
+ * remaining slides are placeholder tiles so the carousel stays navigable until
+ * more charts are built.
  */
 
 /**
- * Placeholder slide mirroring the "flavor of the month" design: a titled card
- * with a subtitle and an empty chart area. Stands in for trending charts that
- * have not been built yet.
+ * Empty chart area standing in for a trending chart that has not been built
+ * yet. The carousel container renders its title/subtitle, so this is only the
+ * body.
  */
-function PlaceholderSlide({ title, subtitle }) {
+function PlaceholderChart() {
   return (
-    <div className="bg-core-white border-border-primary rounded-xl border p-4 shadow-sm sm:p-6">
-      <Heading level={4} className="text-heading-xs">
-        {title}
-      </Heading>
-      <p className="text-paragraph-sm text-content-secondary mt-1">{subtitle}</p>
-      <div
-        className="bg-background-primary mt-4 h-[500px] w-full rounded-lg"
-        aria-hidden="true"
-      />
-    </div>
+    <div
+      className="bg-background-primary h-[580px] w-full rounded-lg"
+      aria-hidden="true"
+    />
   );
 }
-
-PlaceholderSlide.propTypes = {
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
-};
 
 export default function TrendingCarousel() {
   const headingId = useId();
 
   const slides = [
-    <MonthlyOwnershipChangeChart key="ownership-change-volume" />,
-    <PlaceholderSlide
-      key="placeholder-1"
-      title="Flavor of the month"
-      subtitle="Flavor of the month subtitle"
-    />,
-    <PlaceholderSlide
-      key="placeholder-2"
-      title="Flavor of the month"
-      subtitle="Flavor of the month subtitle"
-    />,
+    {
+      title: 'Monthly SNF Ownership Change Volume',
+      subtitle: 'Facilities with ownership changes, by month',
+      content: <MonthlyOwnershipChangeChart />,
+    },
+    {
+      title: 'placeholder1 title',
+      subtitle: 'placeholder1 subtitle',
+      content: <PlaceholderChart />,
+    },
+    {
+      title: 'placeholder2 title',
+      subtitle: 'placeholder2 subtitle',
+      content: <PlaceholderChart />,
+    },
   ];
 
   return (

--- a/src/components/ui/organism/trendingCarousel.jsx
+++ b/src/components/ui/organism/trendingCarousel.jsx
@@ -1,0 +1,65 @@
+import React, { useId } from 'react';
+import PropTypes from 'prop-types';
+import { Heading } from '../atom/heading';
+import Carousel from '../molecule/carousel';
+import MonthlyOwnershipChangeChart from './monthlyOwnershipChangeChart';
+
+/**
+ * @fileoverview "Trending in Nursing Home Data" home-page section.
+ *
+ * Houses the trending charts in an Embla carousel. Today only one real chart
+ * exists (MonthlyOwnershipChangeChart); the remaining slides are placeholder
+ * tiles so the carousel is navigable until more charts are built.
+ */
+
+/**
+ * Placeholder slide mirroring the "flavor of the month" design: a titled card
+ * with a subtitle and an empty chart area. Stands in for trending charts that
+ * have not been built yet.
+ */
+function PlaceholderSlide({ title, subtitle }) {
+  return (
+    <div className="bg-core-white border-border-primary rounded-xl border p-4 shadow-sm sm:p-6">
+      <Heading level={4} className="text-heading-xs">
+        {title}
+      </Heading>
+      <p className="text-paragraph-sm text-content-secondary mt-1">{subtitle}</p>
+      <div
+        className="bg-background-primary mt-4 h-[500px] w-full rounded-lg"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+PlaceholderSlide.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+};
+
+export default function TrendingCarousel() {
+  const headingId = useId();
+
+  const slides = [
+    <MonthlyOwnershipChangeChart key="ownership-change-volume" />,
+    <PlaceholderSlide
+      key="placeholder-1"
+      title="Flavor of the month"
+      subtitle="Flavor of the month subtitle"
+    />,
+    <PlaceholderSlide
+      key="placeholder-2"
+      title="Flavor of the month"
+      subtitle="Flavor of the month subtitle"
+    />,
+  ];
+
+  return (
+    <section aria-labelledby={headingId} className="mx-auto max-w-5xl">
+      <Heading id={headingId} level={2} className="text-heading-sm mb-6">
+        Trending in Nursing Home Data
+      </Heading>
+      <Carousel slides={slides} ariaLabel="Trending in nursing home data" />
+    </section>
+  );
+}

--- a/src/components/ui/organism/trendingCarousel.jsx
+++ b/src/components/ui/organism/trendingCarousel.jsx
@@ -9,9 +9,8 @@ import MonthlyOwnershipChangeChart from './monthlyOwnershipChangeChart';
  * Houses the trending charts in a single Embla carousel container. The
  * container supplies the title/subtitle, arrows, and dot tracker; each slide
  * only provides the body that swaps inside it. Today one real chart exists
- * (MonthlyOwnershipChangeChart, rendered bare via its `embedded` mode); the
- * remaining slides are placeholder tiles so the carousel stays navigable until
- * more charts are built.
+ * (MonthlyOwnershipChangeChart, which renders bare); the remaining slides are
+ * placeholder tiles so the carousel stays navigable until more charts are built.
  */
 
 /**

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,7 +5,7 @@ import { slugify } from '../lib/slugify';
 import { toTitleCase } from '../lib/toTitleCase';
 import OfficeBuildingCircle from '../assets/officeBuildingCircle.jsx';
 import UserGroupCircle from '../assets/userGroupCircle.jsx';
-import MonthlyOwnershipChangeChart from '../components/ui/organism/monthlyOwnershipChangeChart.jsx';
+import TrendingCarousel from '../components/ui/organism/trendingCarousel.jsx';
 import { IndustryListSkeleton } from '../components/ui/atom/skeletons.jsx';
 import { ErrorBanner } from '../components/ui/atom/errorBanner.jsx';
 import StateRankingsHiLowViz from '../components/ui/organism/stateRankingsHiLowViz.jsx';
@@ -227,11 +227,9 @@ export default function Home() {
       <section className="bg-background-secondary min-h-[400px] w-full px-4 pb-8 font-sans sm:px-6 lg:px-8 xl:px-0">
         <StateRankingsHiLowViz />
       </section>
-      {/* Barchart Graphic Section */}
+      {/* Trending charts carousel section */}
       <section className="bg-background-secondary min-h-[400px] w-full px-4 pb-8 font-sans sm:px-6 lg:px-8 xl:px-0">
-        <div className="mx-auto max-w-5xl">
-          <MonthlyOwnershipChangeChart />
-        </div>
+        <TrendingCarousel />
       </section>
     </div>
   );


### PR DESCRIPTION
Introduces an Embla based carousel on the homepage that houses the trending charts.  Today, it holds the existing Monthly SNF Ownership Change Volume chart plus two placeholder slides.

The original Monthly SNF recharts component needed trimming and had a few things removed to fit with the new theme.