### PR TITLE
Global shareability: profile share widgets, Top 10 list export, facility stats CSV(1)

### DIFF
--- a/src/components/ui/molecule/profileHeader.jsx
+++ b/src/components/ui/molecule/profileHeader.jsx
@@ -10,6 +10,7 @@ import {
   copyProfileLink,
   downloadProfileCsv,
 } from '../../../lib/shareability/profileShareActions';
+import { slugify } from '../../../lib/slugify';
 
 /*Custom component using Heading and Badge from TW Catalyst UI Kit  */
 /*Creates the header and badges w/ description atop profiles for Facilty or Owner*/
@@ -32,6 +33,11 @@ export default function ProfileHeader({
      associated facilities for an owner — the caller supplies the rows + column
      config via shareCsvRows/shareCsvConfig). Built only when a config is
      passed, so the widget can be omitted (e.g. in stories). */
+  /* Name the CSV after the profile subject (falls back to the config's static
+     filename when there's no title). */
+  const titleSlug = slugify(title);
+  const csvFilename = titleSlug ? `${titleSlug}.csv` : undefined;
+
   const shareCategories = shareCsvConfig
     ? [
         {
@@ -49,7 +55,8 @@ export default function ProfileHeader({
           loadingLabel: 'Preparing…',
           successLabel: 'Downloaded',
           emptyLabel: 'No data',
-          onClick: () => downloadProfileCsv(shareCsvRows, shareCsvConfig),
+          onClick: () =>
+            downloadProfileCsv(shareCsvRows, shareCsvConfig, csvFilename),
         },
       ]
     : null;

--- a/src/components/ui/molecule/profileHeader.jsx
+++ b/src/components/ui/molecule/profileHeader.jsx
@@ -57,9 +57,9 @@ export default function ProfileHeader({
   const hasControls = years?.length > 0 || shareCategories;
 
   return (
-    <div className="bg-background-secondary my-6 flex flex-col gap-4 font-sans lg:flex-row lg:flex-wrap lg:items-start lg:justify-between">
-      <div>
-        <Heading className="text-display-xs" level={1}>
+    <div className="bg-background-secondary my-6 flex flex-col gap-4 font-sans lg:flex-row lg:items-start lg:justify-between">
+      <div className="lg:min-w-0">
+        <Heading className="text-display-xs wrap-break-word" level={1}>
           {title}
         </Heading>
         <div className="mt-4 flex flex-row gap-2">
@@ -75,7 +75,7 @@ export default function ProfileHeader({
       {/* Right column: data-year + share controls on top, researcher CTA below.
           Left-aligned on mobile (where it wraps under the title), right-aligned
           from lg up where it sits beside the title. */}
-      <div className="flex flex-col items-start gap-4 lg:items-end">
+      <div className="flex flex-col items-start gap-4 lg:shrink-0 lg:items-end">
         {hasControls && (
           <div className="flex items-center gap-3">
             {years?.length > 0 && (

--- a/src/components/ui/molecule/profileHeader.jsx
+++ b/src/components/ui/molecule/profileHeader.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { LinkIcon, TableCellsIcon } from '@heroicons/react/24/outline';
 import { Badge } from '../atom/badge';
 import { Heading } from '../atom/heading';
-import PropTypes from 'prop-types';
 import HeftiResearcherCTA from './heftiResearcherCTA';
+import YearSelector from './yearSelector';
+import { ShareWidget } from './shareability';
+import {
+  copyProfileLink,
+  downloadProfileCsv,
+} from '../../../lib/shareability/profileShareActions';
 
 /*Custom component using Heading and Badge from TW Catalyst UI Kit  */
 /*Creates the header and badges w/ description atop profiles for Facilty or Owner*/
@@ -14,9 +21,43 @@ export default function ProfileHeader({
   func,
   onClick,
   subjectType = 'owner',
+  years,
+  selectedYear,
+  onYearChange,
+  shareCsvRows,
+  shareCsvConfig,
 }) {
+  /* Both profile types get the same two share actions: copy a link to the
+     profile, and download its primary list as CSV (stakeholders for a facility,
+     associated facilities for an owner — the caller supplies the rows + column
+     config via shareCsvRows/shareCsvConfig). Built only when a config is
+     passed, so the widget can be omitted (e.g. in stories). */
+  const shareCategories = shareCsvConfig
+    ? [
+        {
+          icon: LinkIcon,
+          label: 'Copy link',
+          tooltip: 'Copy a link to this profile',
+          successLabel: 'Copied',
+          emptyLabel: 'Copy failed',
+          onClick: copyProfileLink,
+        },
+        {
+          icon: TableCellsIcon,
+          label: 'Download CSV',
+          tooltip: shareCsvConfig.tooltip ?? 'Download as CSV',
+          loadingLabel: 'Preparing…',
+          successLabel: 'Downloaded',
+          emptyLabel: 'No data',
+          onClick: () => downloadProfileCsv(shareCsvRows, shareCsvConfig),
+        },
+      ]
+    : null;
+
+  const hasControls = years?.length > 0 || shareCategories;
+
   return (
-    <div className="bg-background-secondary my-6 flex flex-wrap gap-y-4 font-sans lg:flex-row lg:justify-between">
+    <div className="bg-background-secondary my-6 flex flex-col gap-4 font-sans lg:flex-row lg:flex-wrap lg:items-start lg:justify-between">
       <div>
         <Heading className="text-display-xs" level={1}>
           {title}
@@ -30,7 +71,25 @@ export default function ProfileHeader({
           </p>
         )}
       </div>
-      <div>
+
+      {/* Right column: data-year + share controls on top, researcher CTA below.
+          Left-aligned on mobile (where it wraps under the title), right-aligned
+          from lg up where it sits beside the title. */}
+      <div className="flex flex-col items-start gap-4 lg:items-end">
+        {hasControls && (
+          <div className="flex items-center gap-3">
+            {years?.length > 0 && (
+              <YearSelector
+                years={years}
+                value={selectedYear}
+                onChange={onYearChange}
+              />
+            )}
+            {shareCategories && (
+              <ShareWidget categories={shareCategories} minimizedLabel="Share" />
+            )}
+          </div>
+        )}
         <HeftiResearcherCTA onClick={onClick} subjectType={subjectType} />
       </div>
     </div>
@@ -44,4 +103,16 @@ ProfileHeader.propTypes = {
   func: PropTypes.func,
   onClick: PropTypes.func,
   subjectType: PropTypes.oneOf(['owner', 'facility']),
+  years: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  ),
+  selectedYear: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onYearChange: PropTypes.func,
+  shareCsvRows: PropTypes.array,
+  shareCsvConfig: PropTypes.shape({
+    filename: PropTypes.string.isRequired,
+    headers: PropTypes.arrayOf(PropTypes.string).isRequired,
+    toRow: PropTypes.func.isRequired,
+    tooltip: PropTypes.string,
+  }),
 };

--- a/src/components/ui/molecule/tabsSelector.jsx
+++ b/src/components/ui/molecule/tabsSelector.jsx
@@ -24,7 +24,6 @@ export default function TabsSelector({
   activeTab,
   panelId,
   getTabId,
-  rightSlot,
 }) {
   const handleClick = (tabName) => {
     const newActive = tabsData.find((tab) => tab.name === tabName);
@@ -52,7 +51,6 @@ export default function TabsSelector({
             className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end fill-gray-500"
           />
         </div>
-        {rightSlot && <div className="mt-3">{rightSlot}</div>}
       </div>
       {/** Desktop */}
       <div className="hidden lg:block">
@@ -84,7 +82,6 @@ export default function TabsSelector({
                 </button>
               ))}
             </div>
-            {rightSlot && <div className="mb-3">{rightSlot}</div>}
           </div>
         </div>
       </div>
@@ -104,7 +101,6 @@ TabsSelector.propTypes = {
   onTabChange: PropTypes.func,
   panelId: PropTypes.string,
   getTabId: PropTypes.func,
-  rightSlot: PropTypes.node,
   activeTab: PropTypes.shape({
     name: PropTypes.string.isRequired,
     href: PropTypes.string,

--- a/src/components/ui/molecule/tabsShell.jsx
+++ b/src/components/ui/molecule/tabsShell.jsx
@@ -7,7 +7,7 @@ import TabsSelector from './tabsSelector';
  * Stateful wrapper around the tab selector.
  * It owns the active tab and passes the selected tab back to the page via render props.
  */
-export default function TabsShell({ tabsData, defaultTabName, children, rightSlot }) {
+export default function TabsShell({ tabsData, defaultTabName, children }) {
   // Prefer the requested default tab when present; otherwise fall back to the first tab.
   const defaultTab =
     tabsData.find((tab) => tab.name === defaultTabName) ?? tabsData[0];
@@ -26,7 +26,6 @@ export default function TabsShell({ tabsData, defaultTabName, children, rightSlo
           activeTab={activeTab}
           panelId={panelId}
           getTabId={getTabId}
-          rightSlot={rightSlot}
         />
       </div>
 
@@ -59,5 +58,4 @@ TabsShell.propTypes = {
   ).isRequired,
   defaultTabName: PropTypes.string,
   children: PropTypes.func,
-  rightSlot: PropTypes.node,
 };

--- a/src/components/ui/molecule/yearSelector.jsx
+++ b/src/components/ui/molecule/yearSelector.jsx
@@ -20,14 +20,14 @@ import { Heading } from '../atom/heading';
  *  - years:    array of year values to display
  *  - value:    currently selected year (controlled)
  *  - onChange: called with the selected year when the user picks one
- *  - label:    display label, defaults to "Data Year"
+ *
+ * Renders just the select — no visible label. `label` below is an internal
+ * constant used only for accessible names (aria-label) and the mobile dialog
+ * heading, not shown as on-screen text.
  */
-export default function YearSelector({
-  years = [],
-  value,
-  onChange,
-  label = 'Data Year',
-}) {
+const label = 'Data year';
+
+export default function YearSelector({ years = [], value, onChange }) {
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [pendingYear, setPendingYear] = useState(value);
   const headingId = useId();
@@ -92,15 +92,12 @@ export default function YearSelector({
     <div className="relative">
       {/* Desktop */}
       <div className="hidden items-center gap-2 md:flex">
-        <span className="text-paragraph-sm text-content-secondary">
-          {label}
-        </span>
         <div className="relative">
           <select
             value={value ?? ''}
             onChange={handleDesktopChange}
             aria-label={label}
-            className="focus-ring-light text-label-sm text-content-secondary appearance-none rounded-lg bg-white py-1 pr-8 pl-3 outline-1 -outline-offset-1 outline-gray-300"
+            className="focus-ring-light text-label-sm text-content-secondary h-10 appearance-none rounded-lg bg-white pr-8 pl-3 outline-1 -outline-offset-1 outline-gray-300"
           >
             {years.map((year) => (
               <option key={year} value={year}>
@@ -121,10 +118,9 @@ export default function YearSelector({
           ref={mobileTriggerRef}
           type="button"
           onClick={handleMobileTrigger}
-          className="focus-ring-light text-label-sm text-content-secondary col-start-1 row-start-1 flex items-center gap-2 rounded-md bg-white py-1.5 pr-8 pl-3 text-left outline-1 -outline-offset-1 outline-gray-300"
+          className="focus-ring-light text-label-sm text-content-secondary col-start-1 row-start-1 flex h-10 items-center gap-2 rounded-md bg-white pr-8 pl-3 text-left outline-1 -outline-offset-1 outline-gray-300"
           aria-label={`${label}: ${value}. Activate to change.`}
         >
-          <span className="text-paragraph-base text-core-black">{label}</span>
           <span className="text-paragraph-base text-content-secondary">
             {value}
           </span>
@@ -212,5 +208,4 @@ YearSelector.propTypes = {
   ).isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func.isRequired,
-  label: PropTypes.string,
 };

--- a/src/lib/shareability/profileShareActions.js
+++ b/src/lib/shareability/profileShareActions.js
@@ -1,0 +1,66 @@
+import { copyText, downloadCsv } from './shareActions';
+import { toTitleCase } from '../toTitleCase';
+import { formatOwnershipPercentage } from '../stringFormatters';
+import { ownerRoleMap } from '../ownerRoleHelper';
+
+/**
+ * profileShareActions
+ *
+ * Share actions for the facility and owner profile headers. Mirrors how
+ * rankingShareActions / researchShareActions sit on the generic shareActions.js
+ * primitives: this file owns the profile-specific data shaping (the copy-link
+ * action + the CSV column configs); ProfileHeader builds the ShareWidget
+ * categories from these.
+ *
+ * The CSV for each profile is the primary tabular list on that page:
+ * - Facility profile -> its ownership & stakeholders
+ * - Owner profile    -> its associated facilities
+ */
+
+/* Copies a link to the current profile to the clipboard. Reads the live URL so
+   the copied link carries whatever slug/route the visitor is actually on. */
+export function copyProfileLink() {
+  return copyText(window.location.href);
+}
+
+/* Writes the supplied rows to CSV via the given config. Returns false on an
+   empty set so the ShareWidget segment can surface its empty state instead of
+   downloading a header-only file. */
+export function downloadProfileCsv(rows, config) {
+  if (!rows?.length) return false;
+  return downloadCsv(rows.map(config.toRow), config.filename, config.headers);
+}
+
+/* Facility profile CSV: one row per ownership/stakeholder link
+   (facility.facility_ownership_links), matching the on-page
+   "Ownership and Stakeholders" list. */
+export const facilityStakeholdersExportConfig = {
+  filename: 'ownership-stakeholders.csv',
+  tooltip: 'Download ownership & stakeholders as CSV',
+  headers: ['Owner', 'Ownership Type', 'Role', 'Ownership %'],
+  toRow: (link) => [
+    toTitleCase(link.ownership_entity?.cms_ownership_name || ''),
+    toTitleCase(link.cms_ownership_type || ''),
+    toTitleCase(link.cms_ownership_role || ''),
+    formatOwnershipPercentage(link.cms_ownership_percentage),
+  ],
+};
+
+/* Owner profile CSV: one row per associated facility. Rows are the
+   relatedFacilities the page already derives (facility fields spread with the
+   owner's role on that facility). Owner Role uses the same ownerRoleMap label
+   as the on-page RelatedFacilities card. */
+export const ownerFacilitiesExportConfig = {
+  filename: 'associated-facilities.csv',
+  tooltip: 'Download associated facilities as CSV',
+  headers: ['Name', 'Address', 'City', 'State', 'CMS Rating', 'Owner Role'],
+  toRow: (facility) => [
+    toTitleCase(facility.provider_name || ''),
+    toTitleCase(facility.street_address || ''),
+    toTitleCase(facility.city || ''),
+    facility.state || '',
+    facility.overall_rating ?? '',
+    ownerRoleMap[facility.cms_ownership_role]?.label ??
+      toTitleCase(facility.cms_ownership_role || ''),
+  ],
+};

--- a/src/lib/shareability/profileShareActions.js
+++ b/src/lib/shareability/profileShareActions.js
@@ -1,7 +1,30 @@
 import { copyText, downloadCsv } from './shareActions';
 import { toTitleCase } from '../toTitleCase';
-import { formatOwnershipPercentage } from '../stringFormatters';
+import {
+  formatOwnershipPercentage,
+  formatMetricValue,
+  formatUSD,
+} from '../stringFormatters';
 import { ownerRoleMap } from '../ownerRoleHelper';
+import { buildFacilityCardStats } from '../providerHighlightsMetrics';
+import {
+  buildFacilityLongStayStats,
+  buildFacilityShortStayStats,
+} from '../clinicalQualityMetrics';
+import {
+  buildFacilityStaffingLevels,
+  buildFacilityStaffingTurnover,
+} from '../staffingMetrics';
+import {
+  buildFacilityProfitStats,
+  buildFacilityRevenueStats,
+  buildFacilityExpensesStats,
+  buildFacilityLiquidityStats,
+} from '../financialMetrics';
+import {
+  buildFacilityDeficienciesStats,
+  buildFacilityPenaltiesStats,
+} from '../deficienciesMetrics';
 
 /**
  * profileShareActions
@@ -23,12 +46,17 @@ export function copyProfileLink() {
   return copyText(window.location.href);
 }
 
-/* Writes the supplied rows to CSV via the given config. Returns false on an
-   empty set so the ShareWidget segment can surface its empty state instead of
-   downloading a header-only file. */
-export function downloadProfileCsv(rows, config) {
+/* Writes the supplied rows to CSV via the given config. An optional `filename`
+   overrides config.filename (used to name the file after the profile subject).
+   Returns false on an empty set so the ShareWidget segment can surface its empty
+   state instead of downloading a header-only file. */
+export function downloadProfileCsv(rows, config, filename) {
   if (!rows?.length) return false;
-  return downloadCsv(rows.map(config.toRow), config.filename, config.headers);
+  return downloadCsv(
+    rows.map(config.toRow),
+    filename || config.filename,
+    config.headers,
+  );
 }
 
 /* Facility profile CSV: one row per ownership/stakeholder link
@@ -63,4 +91,84 @@ export const ownerFacilitiesExportConfig = {
     ownerRoleMap[facility.cms_ownership_role]?.label ??
       toTitleCase(facility.cms_ownership_role || ''),
   ],
+};
+
+/* Flattens every facility statistic into Category / Statistic / Value rows for
+   the profile header's "Download CSV". Reuses the exact per-tab metric builders
+   the profile renders from (single source of truth for labels + fields), so the
+   CSV never drifts from the on-screen numbers. Long format because one facility
+   has ~40 metrics — too many for a single wide row — and the Category column
+   disambiguates labels that repeat across sections (e.g. pneumococcal vaccine
+   appears in both long- and short-stay). `nationalBenchmarks` is accepted only
+   because the builders take it; only each metric's own value is exported. */
+export function buildFacilityStatsRows(facility, nationalBenchmarks) {
+  const rows = [];
+  const add = (category, label, value) =>
+    rows.push({
+      category,
+      label,
+      value: value == null || value === '' ? 'N/A' : String(value),
+    });
+
+  [
+    ['Overall Star Rating', 'overall_rating'],
+    ['Health Inspection Rating', 'health_inspection_rating'],
+    ['Staffing Rating', 'staffing_rating'],
+    ['Quality Measures Rating', 'quality_rating'],
+  ].forEach(([label, key]) =>
+    add('Ratings', label, formatMetricValue(facility?.[key])),
+  );
+
+  buildFacilityCardStats(facility).forEach((s) =>
+    add('Provider Highlights', s.key, s.isCurrency ? formatUSD(s.stat) : s.stat),
+  );
+
+  buildFacilityLongStayStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Clinical Quality - Long Stay', s.title, s.value),
+  );
+  buildFacilityShortStayStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Clinical Quality - Short Stay', s.title, s.value),
+  );
+
+  buildFacilityStaffingLevels(facility).forEach((s) =>
+    add('Staffing - Levels', s.key, s.displayStat),
+  );
+  buildFacilityStaffingTurnover(facility).forEach((s) =>
+    add('Staffing - Turnover', s.key, s.displayStat),
+  );
+
+  buildFacilityProfitStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Financial - Profitability', s.title, s.value),
+  );
+  buildFacilityRevenueStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Financial - Revenue', s.title, s.value),
+  );
+  buildFacilityExpensesStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Financial - Expenses', s.title, s.value),
+  );
+  buildFacilityLiquidityStats(facility, nationalBenchmarks).forEach((s) =>
+    add('Financial - Liquidity', s.title, s.value),
+  );
+
+  [
+    ...buildFacilityDeficienciesStats(facility, nationalBenchmarks),
+    ...buildFacilityPenaltiesStats(facility, nationalBenchmarks),
+  ].forEach((s) =>
+    add(
+      'Deficiencies & Penalties',
+      s.key,
+      s.isCurrency ? formatUSD(s.stat) : formatMetricValue(s.stat),
+    ),
+  );
+
+  return rows;
+}
+
+/* Facility profile CSV: all facility statistics (see buildFacilityStatsRows).
+   Rows are the {category, label, value} objects that builder returns. */
+export const facilityStatsExportConfig = {
+  filename: 'facility-statistics.csv',
+  tooltip: 'Download all facility statistics as CSV',
+  headers: ['Category', 'Statistic', 'Value'],
+  toRow: (row) => [row.category, row.label, row.value],
 };

--- a/src/lib/shareability/rankingShareActions.js
+++ b/src/lib/shareability/rankingShareActions.js
@@ -1,0 +1,21 @@
+import { downloadCsv } from './shareActions';
+import { toTitleCase } from '../toTitleCase';
+
+/**
+ * rankingShareActions
+ *
+ * Share actions for ranked entity lists — the recurring `{ name, count }`
+ * shape behind the home page's Top 10 lists, the browse pages, and profile
+ * rankings. Keeping the row/header shaping here (rather than re-deriving it at
+ * each call site) mirrors how chartExport.js owns chart-shape knowledge on top
+ * of the generic primitives in shareActions.js. Page components pass only the
+ * data plus metadata (entity label, filename).
+ */
+
+export function downloadRankingCsv(items, { entityLabel, filename }) {
+  return downloadCsv(
+    items.map((item) => [toTitleCase(item.name), item.count]),
+    filename,
+    [entityLabel, 'Facilities'],
+  );
+}

--- a/src/pages/FacilityProfile.jsx
+++ b/src/pages/FacilityProfile.jsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import React from 'react';
 import LayoutPage from '../components/ui/atom/layout-page';
 import ProfileHeader from '../components/ui/molecule/profileHeader';
@@ -28,7 +28,10 @@ import ListContainer, {
 import OwnershipFlowDiagram from '../components/ui/organism/ownershipFlowDiagram';
 import { OwnershipAndStakeholders } from '../components/ui/molecule/listContainerContent';
 import AdditionalInformation from '../components/ui/molecule/additionalInformation';
-import { facilityStakeholdersExportConfig } from '../lib/shareability/profileShareActions';
+import {
+  facilityStatsExportConfig,
+  buildFacilityStatsRows,
+} from '../lib/shareability/profileShareActions';
 
 const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
@@ -101,6 +104,12 @@ export default function FacilityProfile() {
   // Relationship records used for stakeholders + ownership diagram sections.
   const ownershipLinks = facility?.facility_ownership_links || [];
 
+  // Flattened facility statistics powering the profile header's "Download CSV".
+  const facilityStatsRows = useMemo(
+    () => buildFacilityStatsRows(facility, nationalBenchmarks),
+    [facility, nationalBenchmarks],
+  );
+
   //click handler to open the AI chat
   const handleResearchClick = () => {
     navigate(
@@ -153,8 +162,8 @@ export default function FacilityProfile() {
               years={AVAILABLE_YEARS}
               selectedYear={selectedYear}
               onYearChange={setSelectedYear}
-              shareCsvRows={ownershipLinks}
-              shareCsvConfig={facilityStakeholdersExportConfig}
+              shareCsvRows={facilityStatsRows}
+              shareCsvConfig={facilityStatsExportConfig}
             />
             {/* Shared tab shell; active tab content is chosen in the render function below. */}
             <TabsShell

--- a/src/pages/FacilityProfile.jsx
+++ b/src/pages/FacilityProfile.jsx
@@ -28,7 +28,7 @@ import ListContainer, {
 import OwnershipFlowDiagram from '../components/ui/organism/ownershipFlowDiagram';
 import { OwnershipAndStakeholders } from '../components/ui/molecule/listContainerContent';
 import AdditionalInformation from '../components/ui/molecule/additionalInformation';
-import YearSelector from '../components/ui/molecule/yearSelector';
+import { facilityStakeholdersExportConfig } from '../lib/shareability/profileShareActions';
 
 const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
@@ -150,18 +150,16 @@ export default function FacilityProfile() {
               func={getBadgeColorOwnershipType}
               onClick={handleResearchClick}
               subjectType="facility"
+              years={AVAILABLE_YEARS}
+              selectedYear={selectedYear}
+              onYearChange={setSelectedYear}
+              shareCsvRows={ownershipLinks}
+              shareCsvConfig={facilityStakeholdersExportConfig}
             />
             {/* Shared tab shell; active tab content is chosen in the render function below. */}
             <TabsShell
               tabsData={profileTabsDescriptions}
               defaultTabName={'Provider Highlights'}
-              rightSlot={
-                <YearSelector
-                  years={AVAILABLE_YEARS}
-                  value={selectedYear}
-                  onChange={setSelectedYear}
-                />
-              }
             >
               {(activeTab) => {
                 switch (activeTab.name) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { TableCellsIcon } from '@heroicons/react/24/outline';
 import { Heading } from '../components/ui/atom/heading';
+import {
+  ShareButton,
+  ShareButtonRow,
+  HoverReveal,
+} from '../components/ui/molecule/shareability';
+import { downloadRankingCsv } from '../lib/shareability/rankingShareActions';
 import { slugify } from '../lib/slugify';
 import { toTitleCase } from '../lib/toTitleCase';
 import OfficeBuildingCircle from '../assets/officeBuildingCircle.jsx';
@@ -118,13 +125,30 @@ export default function Home() {
       {/* Bottom (lists) section with gray background */}
       <section className="bg-background-secondary min-h-[400px] w-full px-4 py-8 font-sans sm:px-6 lg:px-8 xl:px-0">
         <div className="mx-auto max-w-5xl">
-          <Heading level={2} className="text-heading-lg my-6 font-semibold text-center">
+          <Heading
+            level={2}
+            className="text-heading-lg my-6 text-center font-semibold"
+          >
             State of the Nursing Home Industry
           </Heading>
           <div className="grid grid-cols-1 gap-8 pt-4 md:grid-cols-2">
-            <div>
-              <div className="mb-4">
+            <div className="group">
+              <div>
                 <Heading level={3}>Top 10 Largest Chains</Heading>
+                <HoverReveal>
+                  <ShareButtonRow>
+                    <ShareButton
+                      icon={TableCellsIcon}
+                      label="Download data as CSV"
+                      onClick={() =>
+                        downloadRankingCsv(topChains, {
+                          entityLabel: 'Chain',
+                          filename: 'top-10-largest-chains.csv',
+                        })
+                      }
+                    />
+                  </ShareButtonRow>
+                </HoverReveal>
               </div>
               {loading ? (
                 <IndustryListSkeleton />
@@ -158,7 +182,7 @@ export default function Home() {
                       </li>
                     ))}
                   </ul>
-                  <div className="pb-8 pt-3 text-center">
+                  <div className="pt-3 pb-8 text-center">
                     <Link
                       to="/rankings/chains"
                       className="text-paragraph-base cursor-pointer text-blue-700 underline hover:text-blue-800"
@@ -169,9 +193,23 @@ export default function Home() {
                 </>
               )}
             </div>
-            <div>
-              <div className="mb-4">
+            <div className="group">
+              <div>
                 <Heading level={3}>Top 10 Largest Individual Owners</Heading>
+                <HoverReveal>
+                  <ShareButtonRow>
+                    <ShareButton
+                      icon={TableCellsIcon}
+                      label="Download data as CSV"
+                      onClick={() =>
+                        downloadRankingCsv(topOwners, {
+                          entityLabel: 'Owner',
+                          filename: 'top-10-largest-individual-owners.csv',
+                        })
+                      }
+                    />
+                  </ShareButtonRow>
+                </HoverReveal>
               </div>
               {loading ? (
                 <IndustryListSkeleton />
@@ -209,7 +247,7 @@ export default function Home() {
                       </li>
                     ))}
                   </ul>
-                  <div className="pb-8 pt-3 text-center">
+                  <div className="pt-3 pb-8 text-center">
                     <Link
                       to="/rankings/individual-owners"
                       className="text-paragraph-base cursor-pointer text-blue-700 underline hover:text-blue-800"

--- a/src/pages/OwnersProfile.jsx
+++ b/src/pages/OwnersProfile.jsx
@@ -24,7 +24,7 @@ import DeficienciesTab from '../components/ui/molecule/tabs/deficienciesTab';
 import ClinicalQualityTab from '../components/ui/molecule/tabs/clinicalQualityTab';
 import StaffingTab from '../components/ui/molecule/tabs/staffingTab';
 import FinancialOverviewTab from '../components/ui/molecule/tabs/financialOverviewTab';
-import YearSelector from '../components/ui/molecule/yearSelector';
+import { ownerFacilitiesExportConfig } from '../lib/shareability/profileShareActions';
 
 /**
  * Owner profile page container.
@@ -141,6 +141,11 @@ export default function OwnersProfile() {
               func={getBadgeColorOwnerProfile}
               onClick={handleResearchClick}
               subjectType="owner"
+              years={AVAILABLE_YEARS}
+              selectedYear={selectedYear}
+              onYearChange={setSelectedYear}
+              shareCsvRows={relatedFacilities}
+              shareCsvConfig={ownerFacilitiesExportConfig}
             />
             <div className="pb-4">
               <OwnersNetworkGraphLauncher ownerId={owner.id} />
@@ -149,13 +154,6 @@ export default function OwnersProfile() {
             <TabsShell
               tabsData={profileTabsDescriptions}
               defaultTabName={'Provider Highlights'}
-              rightSlot={
-                <YearSelector
-                  years={AVAILABLE_YEARS}
-                  value={selectedYear}
-                  onChange={setSelectedYear}
-                />
-              }
             >
               {(activeTab) => {
                 switch (activeTab.name) {


### PR DESCRIPTION
Adds shareable/exportable data across the app, a global share widget on the facility and owner profile headers, CSV download on the home page's Top 10 lists, and a full facility-statistics export. Also relocates the profile year selector into the header and cleans up the now-unused tab slot.