### PR TITLE
Home acquistions cta

### DIFF
--- a/src/components/ui/atom/ctaLinkButton.jsx
+++ b/src/components/ui/atom/ctaLinkButton.jsx
@@ -34,6 +34,7 @@ export default function CtaLinkButton({
     return (
       <a href={to} target="_blank" rel="noopener noreferrer" className={classes}>
         {content}
+        <span className="sr-only"> (opens in new tab)</span>
       </a>
     );
   }

--- a/src/components/ui/atom/ctaLinkButton.jsx
+++ b/src/components/ui/atom/ctaLinkButton.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import clsx from 'clsx';
+
+/* Solid dark button styled call-to-action. An external `to` (http(s):// or //)
+   renders an <a> that opens in a new tab; anything else renders an in-app router
+   Link. `icon` adds a trailing glyph, `fullWidth` fills the container. */
+
+const isExternalUrl = (to) => /^(https?:)?\/\//.test(to);
+
+export default function CtaLinkButton({
+  to,
+  children,
+  icon: Icon,
+  fullWidth = false,
+  className,
+}) {
+  const classes = clsx(
+    'focus-ring-light inline-flex items-center justify-center rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800',
+    Icon && 'gap-2',
+    fullWidth ? 'w-full' : 'shrink-0',
+    className,
+  );
+
+  const content = (
+    <>
+      {children}
+      {Icon && <Icon className="size-5" aria-hidden="true" />}
+    </>
+  );
+
+  if (isExternalUrl(to)) {
+    return (
+      <a href={to} target="_blank" rel="noopener noreferrer" className={classes}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link to={to} className={classes}>
+      {content}
+    </Link>
+  );
+}
+
+CtaLinkButton.propTypes = {
+  to: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  icon: PropTypes.elementType,
+  fullWidth: PropTypes.bool,
+  className: PropTypes.string,
+};

--- a/src/components/ui/molecule/acquisitionsCtaBanner.jsx
+++ b/src/components/ui/molecule/acquisitionsCtaBanner.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { ArrowRightIcon } from '@heroicons/react/20/solid';
+import clsx from 'clsx';
+
+/* Shared purple call-to-action banner for ownership-change / acquisitions
+   sections. Renders the gradient panel and dark link button; the message is
+   passed as children so each surface supplies its own copy. The /acquisitions
+   route doesn't exist yet, so `to` is a placeholder until it's built. */
+
+export default function AcquisitionsCtaBanner({
+  to = '/acquisitions',
+  label,
+  children,
+  background = 'bg-linear-to-r from-purple-50 to-purple-200',
+  className,
+}) {
+  return (
+    <div
+      className={clsx(
+        'border-border-primary flex flex-col gap-4 rounded-xl border px-4 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:px-6',
+        background,
+        className,
+      )}
+    >
+      <p className="text-paragraph-base text-content-primary">{children}</p>
+      <Link
+        to={to}
+        className="focus-ring-light inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800"
+      >
+        {label}
+        <ArrowRightIcon className="size-5" aria-hidden="true" />
+      </Link>
+    </div>
+  );
+}
+
+AcquisitionsCtaBanner.propTypes = {
+  to: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  background: PropTypes.string,
+  className: PropTypes.string,
+};

--- a/src/components/ui/molecule/acquisitionsCtaBanner.jsx
+++ b/src/components/ui/molecule/acquisitionsCtaBanner.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { ArrowRightIcon } from '@heroicons/react/20/solid';
 import clsx from 'clsx';
+import CtaLinkButton from '../atom/ctaLinkButton';
 
 /* Shared purple call-to-action banner for ownership-change / acquisitions
    sections. Renders the gradient panel and dark link button; the message is
@@ -25,13 +25,9 @@ export default function AcquisitionsCtaBanner({
       )}
     >
       <p className="text-paragraph-base text-content-primary">{children}</p>
-      <Link
-        to={to}
-        className="focus-ring-light inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800"
-      >
+      <CtaLinkButton to={to} icon={ArrowRightIcon}>
         {label}
-        <ArrowRightIcon className="size-5" aria-hidden="true" />
-      </Link>
+      </CtaLinkButton>
     </div>
   );
 }

--- a/src/components/ui/molecule/stateAcquisitionsCta.jsx
+++ b/src/components/ui/molecule/stateAcquisitionsCta.jsx
@@ -1,29 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { ArrowRightIcon } from '@heroicons/react/20/solid';
+import AcquisitionsCtaBanner from './acquisitionsCtaBanner';
 
 /* Ownership-changes call-to-action for the State Profile page. Summarizes how
-   many ownership changes were recorded across the state and links out to the
-   acquisitions page. That page doesn't exist yet, so the link is a placeholder
-   until the route is built. */
+   many ownership changes were recorded across the state. */
 
-export default function StateAcquisitionsCta({ stateName, changeCount, to }) {
+export default function StateAcquisitionsCta({
+  stateName,
+  changeCount,
+  to = '/acquisitions',
+}) {
   return (
-    <div className="border-border-primary mt-8 flex flex-col gap-4 rounded-xl border bg-linear-to-r from-purple-50 to-purple-200 px-4 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:px-6">
-      <p className="text-paragraph-base text-content-primary">
-        HEFTI has recorded{' '}
-        <span className="font-bold">{changeCount} ownership changes</span>{' '}
-        across {stateName} facilities in the past year.
-      </p>
-      <Link
-        to={to}
-        className="focus-ring-light inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800"
-      >
-        View ownership records
-        <ArrowRightIcon className="size-5" aria-hidden="true" />
-      </Link>
-    </div>
+    <AcquisitionsCtaBanner to={to} label="View ownership records" className="mt-8">
+      HEFTI has recorded{' '}
+      <span className="font-bold">{changeCount} ownership changes</span> across{' '}
+      {stateName} facilities in the past year.
+    </AcquisitionsCtaBanner>
   );
 }
 
@@ -31,8 +23,4 @@ StateAcquisitionsCta.propTypes = {
   stateName: PropTypes.string.isRequired,
   changeCount: PropTypes.number.isRequired,
   to: PropTypes.string,
-};
-
-StateAcquisitionsCta.defaultProps = {
-  to: '/acquisitions',
 };

--- a/src/components/ui/molecule/tabsSelector.jsx
+++ b/src/components/ui/molecule/tabsSelector.jsx
@@ -103,7 +103,7 @@ export default function TabsSelector({
                   <span
                     aria-hidden="true"
                     className={classNames(
-                      active ? 'bg-indigo-700' : 'bg-transparent',
+                      active ? 'bg-purple-600' : 'bg-transparent',
                       'absolute inset-x-0 bottom-0 h-0.5',
                     )}
                   />

--- a/src/components/ui/organism/homeAcquisitionsCta.jsx
+++ b/src/components/ui/organism/homeAcquisitionsCta.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { ArrowRightIcon } from '@heroicons/react/20/solid';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
+import { Heading } from '../atom/heading';
+
+const WINDOW_DAYS = 30;
+const TOTAL_CHANGES = 16;
+
+// TODO: replace with the ownership-changes feed endpoint when the backend ships.
+const RECENT_DEALS = [
+  {
+    id: '1',
+    buyer: 'Ridgeline Senior Care',
+    seller: 'Meridian Care Partners',
+    facilityCount: 7,
+    date: '2026-06-18',
+  },
+  {
+    id: '2',
+    buyer: 'Cascade Care Group LLC',
+    seller: 'Prospect Holding LLC',
+    facilityCount: 1,
+    date: '2026-06-14',
+  },
+  {
+    id: '3',
+    buyer: 'Northstar Healthcare Holdings',
+    seller: 'Sable Point Capital',
+    facilityCount: 3,
+    date: '2026-06-09',
+  },
+  {
+    id: '4',
+    buyer: 'Halcyon Post-Acute Group',
+    seller: 'Bayard Health Partners',
+    facilityCount: 12,
+    date: '2026-06-05',
+  },
+  {
+    id: '5',
+    buyer: 'Kestrel Care Holdings',
+    seller: 'Diversicare Holdings',
+    facilityCount: 2,
+    date: '2026-06-03',
+  },
+];
+
+function facilityLabel(count) {
+  return `${count} ${count === 1 ? 'facility' : 'facilities'}`;
+}
+
+function formatFeedDate(iso) {
+  const d = new Date(`${iso}T00:00:00`);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function FeedRow({ deal, isLast }) {
+  const date = formatFeedDate(deal.date);
+
+  return (
+    <li className="relative pb-6">
+      {!isLast && (
+        <span
+          aria-hidden="true"
+          className="bg-border-primary absolute top-4 left-4 -ml-px h-full w-px"
+        />
+      )}
+      <div className="relative flex items-start gap-3">
+        <span className="flex size-8 flex-none items-center justify-center rounded-full bg-purple-600 text-white ring-8 ring-white">
+          <ArrowsRightLeftIcon className="size-4" aria-hidden="true" />
+        </span>
+        <span className="flex min-w-0 flex-1 justify-between gap-5 pt-[5px]">
+          <span className="text-content-primary text-paragraph-base line-clamp-2">
+            <b className="font-semibold">{deal.buyer}</b>{' '}
+            <span className="text-content-secondary font-normal">
+              acquired {facilityLabel(deal.facilityCount)} from
+            </span>{' '}
+            <b className="font-semibold">{deal.seller}</b>
+          </span>
+          {date && (
+            <time
+              dateTime={deal.date}
+              className="text-content-secondary text-label-xs pt-0.5 whitespace-nowrap"
+            >
+              {date}
+            </time>
+          )}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+FeedRow.propTypes = {
+  deal: PropTypes.shape({
+    buyer: PropTypes.string.isRequired,
+    seller: PropTypes.string.isRequired,
+    facilityCount: PropTypes.number.isRequired,
+    date: PropTypes.string.isRequired,
+  }).isRequired,
+  isLast: PropTypes.bool.isRequired,
+};
+
+export default function HomeAcquisitionsCta({ to = '/acquisitions' }) {
+  const deals = RECENT_DEALS;
+
+  return (
+    <section className="bg-background-secondary w-full px-4 pb-8 font-sans sm:px-6 lg:px-8 xl:px-0">
+      <div className="mx-auto max-w-5xl">
+        <Heading level={2} className="text-heading-lg font-semibold">
+          Latest Ownership Changes
+        </Heading>
+        <p className="text-content-secondary text-paragraph-base mt-1.5">
+          Facility acquisitions and ownership transitions, as reported to CMS.
+        </p>
+
+        <div className="border-border-primary mt-5 rounded-xl border bg-white shadow-sm">
+          <div className="px-6 pt-6">
+            {deals.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-content-primary text-label-base">
+                  No ownership changes recorded in the last {WINDOW_DAYS} days
+                </p>
+                <p className="text-content-secondary text-paragraph-sm mt-1">
+                  New filings are added as CMS sources are processed.
+                </p>
+              </div>
+            ) : (
+              <ul className="-mb-6 list-none">
+                {deals.map((deal, i) => (
+                  <FeedRow
+                    key={deal.id}
+                    deal={deal}
+                    isLast={i === deals.length - 1}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="border-border-primary mt-6 flex flex-col gap-4 border-t px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+            <p className="text-content-secondary text-paragraph-base">
+              <b className="text-content-primary text-heading-sm mr-1">
+                {TOTAL_CHANGES}
+              </b>
+              ownership {TOTAL_CHANGES === 1 ? 'change' : 'changes'} in the last{' '}
+              {WINDOW_DAYS} days
+            </p>
+            <Link
+              to={to}
+              className="focus-ring-light inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800"
+            >
+              View all ownership changes
+              <ArrowRightIcon className="size-5" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+HomeAcquisitionsCta.propTypes = {
+  to: PropTypes.string,
+};

--- a/src/components/ui/organism/homeAcquisitionsCta.jsx
+++ b/src/components/ui/organism/homeAcquisitionsCta.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { ArrowRightIcon } from '@heroicons/react/20/solid';
 import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import { Heading } from '../atom/heading';
+import LayoutCard from '../atom/layout-card';
+import AcquisitionsCtaBanner from '../molecule/acquisitionsCtaBanner';
 
 const WINDOW_DAYS = 30;
 const TOTAL_CHANGES = 16;
@@ -114,12 +114,12 @@ export default function HomeAcquisitionsCta({ to = '/acquisitions' }) {
         <Heading level={2} className="text-heading-lg font-semibold">
           Latest Ownership Changes
         </Heading>
-        <p className="text-content-secondary text-paragraph-base mt-1.5">
+        <p className="text-content-primary text-paragraph-base mt-1.5">
           Facility acquisitions and ownership transitions, as reported to CMS.
         </p>
 
-        <div className="border-border-primary mt-5 rounded-xl border bg-white shadow-sm">
-          <div className="px-6 pt-6">
+        <div className="mt-5">
+          <LayoutCard>
             {deals.length === 0 ? (
               <div className="py-8 text-center">
                 <p className="text-content-primary text-label-base">
@@ -140,24 +140,19 @@ export default function HomeAcquisitionsCta({ to = '/acquisitions' }) {
                 ))}
               </ul>
             )}
-          </div>
 
-          <div className="border-border-primary mt-6 flex flex-col gap-4 border-t px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-            <p className="text-content-secondary text-paragraph-base">
+            <AcquisitionsCtaBanner
+              to={to}
+              label="View all ownership changes"
+              className="mt-6"
+            >
               <b className="text-content-primary text-heading-sm mr-1">
                 {TOTAL_CHANGES}
               </b>
               ownership {TOTAL_CHANGES === 1 ? 'change' : 'changes'} in the last{' '}
               {WINDOW_DAYS} days
-            </p>
-            <Link
-              to={to}
-              className="focus-ring-light inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800"
-            >
-              View all ownership changes
-              <ArrowRightIcon className="size-5" aria-hidden="true" />
-            </Link>
-          </div>
+            </AcquisitionsCtaBanner>
+          </LayoutCard>
         </div>
       </div>
     </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -18,6 +18,7 @@ import { ErrorBanner } from '../components/ui/atom/errorBanner.jsx';
 import StateRankingsHiLowViz from '../components/ui/organism/stateRankingsHiLowViz.jsx';
 import ExploreByState from '../components/ui/organism/exploreByState.jsx';
 import HomeAcquisitionsCta from '../components/ui/organism/homeAcquisitionsCta.jsx';
+import CtaLinkButton from '../components/ui/atom/ctaLinkButton';
 
 /**
  * Home page
@@ -37,9 +38,6 @@ export default function Home() {
   const API_BASE_URL =
     import.meta.env.VITE_API_BASE_URL ||
     'http://hefti-data-api.ddev.site:3000/api';
-
-  const heroCtaClasses =
-    'focus-ring-light inline-flex w-full items-center justify-center rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-800';
 
   useEffect(() => {
     setLoading(true);
@@ -98,9 +96,9 @@ export default function Home() {
                 <span>View nursing home profile pages</span>
               </li>
             </ul>
-            <Link to="/facilities" className={heroCtaClasses}>
+            <CtaLinkButton to="/facilities" fullWidth>
               Browse Nursing Homes
-            </Link>
+            </CtaLinkButton>
           </div>
           <div className="border-content-tertiary flex flex-1 flex-col items-center rounded-xl border bg-[radial-gradient(circle_at_top_right,_#E9D5FF_20%,_#FAF5FF_60%)] p-5 shadow-sm">
             <UserGroupCircle className="mb-3 h-16 w-16" />
@@ -117,9 +115,9 @@ export default function Home() {
                 <span>View profile pages for owners</span>
               </li>
             </ul>
-            <Link to="/owners" className={heroCtaClasses}>
+            <CtaLinkButton to="/owners" fullWidth>
               Browse Owners
-            </Link>
+            </CtaLinkButton>
           </div>
         </div>
       </section>
@@ -268,8 +266,9 @@ export default function Home() {
           </div>
         </div>
       </section>
-      {/* Latest ownership changes feed + acquisitions-tracker CTA */}
-      <HomeAcquisitionsCta />
+      {/* Latest ownership changes feed + acquisitions-tracker CTA.
+          TEMP: `to` points at an external demo until the /acquisitions route ships. */}
+      <HomeAcquisitionsCta to="https://yutingfan1209.github.io/nursing-home-live-feed/" />
       {/*State Ranking Data Table Visuals */}
       <section className="bg-background-secondary min-h-[400px] w-full px-4 pb-8 font-sans sm:px-6 lg:px-8 xl:px-0">
         <StateRankingsHiLowViz />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -17,6 +17,7 @@ import { IndustryListSkeleton } from '../components/ui/atom/skeletons.jsx';
 import { ErrorBanner } from '../components/ui/atom/errorBanner.jsx';
 import StateRankingsHiLowViz from '../components/ui/organism/stateRankingsHiLowViz.jsx';
 import ExploreByState from '../components/ui/organism/exploreByState.jsx';
+import HomeAcquisitionsCta from '../components/ui/organism/homeAcquisitionsCta.jsx';
 
 /**
  * Home page
@@ -267,6 +268,8 @@ export default function Home() {
           </div>
         </div>
       </section>
+      {/* Latest ownership changes feed + acquisitions-tracker CTA */}
+      <HomeAcquisitionsCta />
       {/*State Ranking Data Table Visuals */}
       <section className="bg-background-secondary min-h-[400px] w-full px-4 pb-8 font-sans sm:px-6 lg:px-8 xl:px-0">
         <StateRankingsHiLowViz />

--- a/src/pages/StatesProfile.jsx
+++ b/src/pages/StatesProfile.jsx
@@ -224,10 +224,12 @@ export default function StatesProfile() {
             </TabsShell>
 
             {/* Ownership-changes CTA. changeCount is a placeholder until the
-                state-stats API exposes an annual ownership-change total. */}
+                state-stats API exposes an annual ownership-change total.
+                TEMP: `to` points at an external demo until the /acquisitions route ships. */}
             <StateAcquisitionsCta
               stateName={expandStateAbbreviation(stateStats.state)}
               changeCount={15}
+              to="https://yutingfan1209.github.io/nursing-home-live-feed/"
             />
           </>
         )}


### PR DESCRIPTION
Adds a "Latest Ownership Changes" section to the home page and, in the process, extracts the repeated CTA button/banner markup into shared components. The acquisitions destination doesn't exist yet, so both CTAs temporarily point at a stakeholder demo site.